### PR TITLE
Fix command handlers: DAP_Info/PacketSize, DAP_Disconnect

### DIFF
--- a/src/cmsis_dap.rs
+++ b/src/cmsis_dap.rs
@@ -336,7 +336,8 @@ fn dap_info(request: &[u8], response: &mut [u8]) -> core::result::Result<(usize,
                 },
                 DapInfoId::PacketSize => {
                     buffer[0] = 64;
-                    1 as usize
+                    buffer[1] = 0;
+                    2 as usize
                 },
                 _ => {0 as usize},
             }

--- a/src/cmsis_dap.rs
+++ b/src/cmsis_dap.rs
@@ -360,14 +360,9 @@ fn dap_connect<Swd: SwdIo>(swdio: &mut Swd, request: &[u8], response: &mut [u8])
     }
 }
 fn dap_disconnect<Swd: SwdIo>(swdio: &mut Swd, request: &[u8], response: &mut [u8]) -> core::result::Result<(usize, usize), DapError> {
-    if request.len() >= 1 {
-        swdio.disconnect();
-        response[0] = DAP_OK;
-        Ok((0, 1))
-    }
-    else {
-        Err(DapError::InvalidCommand)
-    }
+    swdio.disconnect();
+    response[0] = DAP_OK;
+    Ok((0, 1))
 }
 fn dap_host_status(request: &[u8], response: &mut [u8]) -> core::result::Result<(usize, usize), DapError> {
     if request.len() >= 1 {


### PR DESCRIPTION
この PR には以下の修正が含まれます。

- DAP_Info の Get the maximum Packet Size のレスポンスが BYTE になっていたのを SHORT に修正
  - https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__Info.html
  - SHORT は little-endian
    - https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__swo__gr.html
- DAP_Disconnect が1バイト以上のリクエストを期待してしまっていたのを修正
  - DAP_Disconnect のリクエスト（コマンド ID 部を除く）は常に0バイト
  - https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__Disconnect.html

probe-rs(probe-run) と組み合わせて使おうとして気づきました。