### PR TITLE
Seeed XIAO(m0)でprobe-runする際のconfigを修正

### DIFF
--- a/boards/xiao_m0/.cargo/config.toml
+++ b/boards/xiao_m0/.cargo/config.toml
@@ -3,7 +3,7 @@ target = "thumbv6m-none-eabi"
 
 [target.thumbv6m-none-eabi]
 runner = "hf2 elf"
-#runner = "probe-run --chip atsamd51p19a"
+#runner = "probe-run --chip atsamd21g18a"
 rustflags = [
   "-C", "link-arg=-Tlink.x", "-C", "link-arg=--nmagic",
 ]


### PR DESCRIPTION
probe-runで指定するチップの型番が間違っていたので修正しました。