### PR TITLE
Remove non-existent crate to build xiao_rp2040

### DIFF
--- a/boards/xiao_rp2040/Cargo.lock
+++ b/boards/xiao_rp2040/Cargo.lock
@@ -66,10 +66,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "blockbuffer"
-version = "0.1.0"
-
-[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,7 +576,6 @@ dependencies = [
 name = "rust-dap-xiao-rp2040"
 version = "0.1.0"
 dependencies = [
- "blockbuffer",
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-rtic",

--- a/boards/xiao_rp2040/Cargo.toml
+++ b/boards/xiao_rp2040/Cargo.toml
@@ -12,7 +12,6 @@ debug = 2
 
 [dependencies]
 rust-dap = { path = "../..", features = ["bitbang", "unproven"] }
-blockbuffer = { path = "../../blockbuffer" }
 rp-pico = { git = "https://github.com/rp-rs/rp-hal.git", rev = "8d18abdfc7c0129debba85457d32d32175bf36bd" }
 panic-halt = "0.2"
 cortex-m = "0.7"


### PR DESCRIPTION
blockbuffer crateのパスにファイルが存在せず、ビルドできなかったので Cargo.toml から削除しました。
