### PR TITLE
RP2040ポートのボードのシリアル番号をボード名称に変更する

### DIFF
--- a/boards/rpi_pico/src/main.rs
+++ b/boards/rpi_pico/src/main.rs
@@ -160,7 +160,7 @@ mod app {
             swdio_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
             swdio = SwdIoSet::new(c.device.PIO0, swclk_pin, swdio_pin, &mut resets);
         }
-        let (usb_serial, usb_dap, usb_bus) = initialize_usb(swdio, usb_allocator);
+        let (usb_serial, usb_dap, usb_bus) = initialize_usb(swdio, usb_allocator, "raspberry-pi-pico");
 
         let usb_led = pins.led.into_push_pull_output();
         let (uart_rx_producer, uart_rx_consumer) = c.local.uart_rx_queue.split();

--- a/boards/xiao_rp2040/src/main.rs
+++ b/boards/xiao_rp2040/src/main.rs
@@ -160,7 +160,7 @@ mod app {
             swdio_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
             swdio = SwdIoSet::new(c.device.PIO0, swclk_pin, swdio_pin, &mut resets);
         }
-        let (usb_serial, usb_dap, usb_bus) = initialize_usb(swdio, usb_allocator);
+        let (usb_serial, usb_dap, usb_bus) = initialize_usb(swdio, usb_allocator, "xiao-rp2040");
 
         let usb_led = pins.led.into_push_pull_output();
         let (uart_rx_producer, uart_rx_consumer) = c.local.uart_rx_queue.split();

--- a/rust-dap-rp2040/src/util.rs
+++ b/rust-dap-rp2040/src/util.rs
@@ -79,13 +79,14 @@ pub struct UartConfigAndClock {
 type PicoUsbBusAllocator = UsbBusAllocator<UsbBus>;
 
 /// Initialize SWDIO, USB-UART, CMSIS-DAP and USB BUS.
-pub fn initialize_usb<Swd, const MAX_PACKET_SIZE: usize>(
+pub fn initialize_usb<'a, Swd, const MAX_PACKET_SIZE: usize>(
     swdio: Swd,
-    usb_allocator: &'static PicoUsbBusAllocator,
+    usb_allocator: &'a PicoUsbBusAllocator,
+    serial: &'a str,
 ) -> (
-    SerialPort<UsbBus>,
-    CmsisDap<'static, UsbBus, Swd, MAX_PACKET_SIZE>,
-    UsbDevice<UsbBus>,
+    SerialPort<'a, UsbBus>,
+    CmsisDap<'a, UsbBus, Swd, MAX_PACKET_SIZE>,
+    UsbDevice<'a, UsbBus>,
 )
 where
     Swd: SwdIo,
@@ -95,7 +96,7 @@ where
     let usb_bus = UsbDeviceBuilder::new(usb_allocator, UsbVidPid(0x6666, 0x4444))
         .manufacturer("fugafuga.org")
         .product("CMSIS-DAP")
-        .serial_number("test")
+        .serial_number(serial)
         .device_class(USB_CLASS_MISCELLANEOUS)
         .device_class(USB_SUBCLASS_COMMON)
         .device_protocol(USB_PROTOCOL_IAD)


### PR DESCRIPTION
https://github.com/ciniml/rust-dap/issues/22

識別できなくて不便だったので変更