### PR TITLE
Initial support for JTAG interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.vscode

--- a/boards/rpi_pico/.gitignore
+++ b/boards/rpi_pico/.gitignore
@@ -1,1 +1,2 @@
 /target
+.vscode/

--- a/boards/rpi_pico/Cargo.lock
+++ b/boards/rpi_pico/Cargo.lock
@@ -576,7 +576,6 @@ dependencies = [
 name = "rust-dap-raspberrypi-pico"
 version = "0.1.0"
 dependencies = [
- "cortex-m",
  "cortex-m-rt",
  "cortex-m-rtic",
  "embedded-hal",

--- a/boards/rpi_pico/Cargo.lock
+++ b/boards/rpi_pico/Cargo.lock
@@ -576,6 +576,7 @@ dependencies = [
 name = "rust-dap-raspberrypi-pico"
 version = "0.1.0"
 dependencies = [
+ "cortex-m",
  "cortex-m-rt",
  "cortex-m-rtic",
  "embedded-hal",

--- a/boards/rpi_pico/Cargo.toml
+++ b/boards/rpi_pico/Cargo.toml
@@ -12,7 +12,9 @@ debug = 2
 
 [features]
 bitbang = ["rust-dap/bitbang", "rust-dap-rp2040/bitbang"]
+jtag = ["bitbang"]
 swd = []
+swj = []
 
 [dependencies]
 rust-dap = { path = "../../rust-dap", features = ["unproven"] }

--- a/boards/rpi_pico/Cargo.toml
+++ b/boards/rpi_pico/Cargo.toml
@@ -12,6 +12,7 @@ debug = 2
 
 [features]
 bitbang = ["rust-dap/bitbang", "rust-dap-rp2040/bitbang"]
+swd = []
 
 [dependencies]
 rust-dap = { path = "../../rust-dap", features = ["unproven"] }

--- a/boards/rpi_pico/src/main.rs
+++ b/boards/rpi_pico/src/main.rs
@@ -205,7 +205,7 @@ mod app {
             initialize_usb(
                 swdio,
                 usb_allocator,
-                "raspberry-pi-pico",
+                "raspberry-pi-pico-swd",
                 DapCapabilities::SWD,
             )
         };
@@ -235,7 +235,7 @@ mod app {
             initialize_usb(
                 jtagio,
                 usb_allocator,
-                "raspberry-pi-pico",
+                "raspberry-pi-pico-jtag",
                 DapCapabilities::JTAG,
             )
         };

--- a/boards/rpi_pico/src/main.rs
+++ b/boards/rpi_pico/src/main.rs
@@ -67,7 +67,7 @@ mod app {
     #[cfg(feature = "swd")]
     type GpioSwClk = hal::gpio::bank0::Gpio2;
     #[cfg(feature = "swd")]
-    type GpioSwdIo = hal::gpio::bank0::Gpio4;
+    type GpioSwdIo = hal::gpio::bank0::Gpio3;
     // jtag
     #[cfg(feature = "jtag")]
     type JtagTmsPin = hal::gpio::bank0::Gpio11;
@@ -191,13 +191,13 @@ mod app {
             {
                 use rust_dap_rp2040::{swdio_pin::PicoSwdInputPin, util::CycleDelay};
                 let swclk_pin = PicoSwdInputPin::new(pins.gpio2.into_floating_input());
-                let swdio_pin = PicoSwdInputPin::new(pins.gpio4.into_floating_input());
+                let swdio_pin = PicoSwdInputPin::new(pins.gpio3.into_floating_input());
                 swdio = SwdIoSet::new(swclk_pin, swdio_pin, CycleDelay {});
             }
             #[cfg(not(feature = "bitbang"))]
             {
                 let mut swclk_pin = pins.gpio2.into_mode();
-                let mut swdio_pin = pins.gpio4.into_mode();
+                let mut swdio_pin = pins.gpio3.into_mode();
                 swclk_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
                 swdio_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
                 swdio = SwdIoSet::new(c.device.PIO0, swclk_pin, swdio_pin, &mut resets);

--- a/rust-dap-rp2040/src/pio.rs
+++ b/rust-dap-rp2040/src/pio.rs
@@ -400,3 +400,107 @@ impl<C, D> SwdIo for SwdIoSet<C, D> {
         // Disabling of output is inherent in read_bits()
     }
 }
+
+impl<C, D> CmsisDapCommandInner for SwdIoSet<C, D> {
+    fn connect(&mut self, _config: &CmsisDapConfig) {
+        SwdIo::connect(self);
+    }
+    fn disconnect(&mut self, _config: &CmsisDapConfig) {
+        SwdIo::disconnect(self);
+    }
+
+    fn swj_sequence(&mut self, config: &CmsisDapConfig, count: usize, data: &[u8]) {
+        SwdIo::swj_sequence(self, &config.swdio, count, data);
+    }
+
+    fn swd_sequence(
+        &mut self,
+        config: &CmsisDapConfig,
+        request: &[u8],
+        response: &mut [u8],
+    ) -> core::result::Result<(usize, usize), DapError> {
+        if request.len() > 0 {
+            let mut sequence_count = request[0];
+            let mut request_index = 1;
+            let mut response_index = 1;
+            while sequence_count > 0 {
+                sequence_count -= 1;
+                let sequence_info = request[request_index];
+                request_index += 1;
+
+                let clock_count = if sequence_info & SWD_SEQUENCE_CLOCK == 0 {
+                    64
+                } else {
+                    sequence_info & SWD_SEQUENCE_CLOCK
+                } as usize;
+                let bytes_count = (clock_count + 7) >> 3;
+                let do_input = sequence_info & SWD_SEQUENCE_DIN != 0;
+
+                if do_input {
+                    SwdIo::disable_output(self);
+                    SwdIo::swd_read_sequence(
+                        self,
+                        &config.swdio,
+                        clock_count,
+                        &mut response[response_index..],
+                    );
+                } else {
+                    SwdIo::enable_output(self);
+                    SwdIo::swd_write_sequence(
+                        self,
+                        &config.swdio,
+                        clock_count,
+                        &request[request_index..],
+                    );
+                }
+
+                if sequence_count == 0 {
+                    SwdIo::enable_output(self)
+                }
+
+                if do_input {
+                    request_index += 1;
+                    response_index += bytes_count;
+                } else {
+                    request_index = 1 + bytes_count;
+                }
+            }
+            response[0] = DAP_OK;
+            Ok((request_index, response_index))
+        } else {
+            Err(DapError::InvalidCommand)
+        }
+    }
+
+    fn transfer_inner_with_retry(
+        &mut self,
+        config: &CmsisDapConfig,
+        _dap_index: u8,
+        request: SwdRequest,
+        data: u32,
+    ) -> core::result::Result<u32, DapError> {
+        let mut retry_count = 0;
+        loop {
+            match SwdIo::swd_transfer(self, &config.swdio, request, data) {
+                Ok(value) => break Ok(value),
+                Err(DapError::SwdError(err)) => {
+                    if err != DAP_TRANSFER_WAIT || retry_count == config.retry_count {
+                        break Err(DapError::SwdError(err));
+                    }
+                    retry_count += 1;
+                }
+                Err(err) => break Err(err),
+            }
+        }
+    }
+    fn swj_pins(
+        &mut self,
+        _config: &CmsisDapConfig,
+        _pin_output: u8,
+        _pin_select: u8,
+        _wait_us: u32,
+    ) -> core::result::Result<u8, DapError> {
+        Err(DapError::InvalidCommand)
+    }
+
+}

--- a/rust-dap-rp2040/src/pio.rs
+++ b/rust-dap-rp2040/src/pio.rs
@@ -500,7 +500,8 @@ impl<C, D> CmsisDapCommandInner for SwdIoSet<C, D> {
         _pin_select: u8,
         _wait_us: u32,
     ) -> core::result::Result<u8, DapError> {
-        Err(DapError::InvalidCommand)
+        // TODO: write
+        Ok(0)
     }
 
     fn jtag_idcode(

--- a/rust-dap-rp2040/src/pio.rs
+++ b/rust-dap-rp2040/src/pio.rs
@@ -503,4 +503,21 @@ impl<C, D> CmsisDapCommandInner for SwdIoSet<C, D> {
         Err(DapError::InvalidCommand)
     }
 
+    fn jtag_idcode(
+        &self,
+        _config: &mut CmsisDapConfig,
+        _request: &[u8],
+        _response: &mut [u8],
+    ) -> core::result::Result<(usize, usize), DapError> {
+        Err(DapError::InvalidCommand)
+    }
+
+    fn jtag_sequence(
+        &mut self,
+        _config: &CmsisDapConfig,
+        _sequence_info: &JtagSequenceInfo,
+        _tdi_data: u64,
+    ) -> core::result::Result<Option<u64>, DapError> {
+        Err(DapError::InvalidCommand)
+    }
 }

--- a/rust-dap-rp2040/src/util.rs
+++ b/rust-dap-rp2040/src/util.rs
@@ -28,13 +28,29 @@ use usbd_serial::SerialPort;
 #[cfg(feature = "bitbang")]
 use crate::swdio_pin::{PicoSwdInputPin, PicoSwdOutputPin};
 #[cfg(feature = "bitbang")]
-use rust_dap::bitbang::{DelayFunc, SwdIoSet as BitbangSwdIoSet};
+use rust_dap::bitbang::{DelayFunc, JtagIoSet as BitbangJtagIoSet, SwdIoSet as BitbangSwdIoSet};
 #[cfg(feature = "bitbang")]
 pub type SwdIoSet<C, D> = BitbangSwdIoSet<
     PicoSwdInputPin<C>,
     PicoSwdOutputPin<C>,
     PicoSwdInputPin<D>,
     PicoSwdOutputPin<D>,
+    CycleDelay,
+>;
+#[cfg(feature = "bitbang")]
+pub type JtagIoSet<TCK, TMS, TDI, TDO, TRST, SRST> = BitbangJtagIoSet<
+    PicoSwdInputPin<TCK>,
+    PicoSwdOutputPin<TCK>,
+    PicoSwdInputPin<TMS>,
+    PicoSwdOutputPin<TMS>,
+    PicoSwdInputPin<TDI>,
+    PicoSwdOutputPin<TDI>,
+    PicoSwdInputPin<TDO>,
+    PicoSwdOutputPin<TDO>,
+    PicoSwdInputPin<TRST>,
+    PicoSwdOutputPin<TRST>,
+    PicoSwdInputPin<SRST>,
+    PicoSwdOutputPin<SRST>,
     CycleDelay,
 >;
 

--- a/rust-dap-rp2040/src/util.rs
+++ b/rust-dap-rp2040/src/util.rs
@@ -18,7 +18,9 @@ use crate::line_coding::UartConfig;
 use core::result::Result;
 use hal::usb::UsbBus;
 use rp2040_hal as hal;
-use rust_dap::{CmsisDap, SwdIo, USB_CLASS_MISCELLANEOUS, USB_PROTOCOL_IAD, USB_SUBCLASS_COMMON};
+use rust_dap::{
+    CmsisDap, DapCapabilities, USB_CLASS_MISCELLANEOUS, USB_PROTOCOL_IAD, USB_SUBCLASS_COMMON,
+};
 use usb_device::device::{UsbDevice, UsbDeviceBuilder, UsbVidPid};
 use usb_device::{class_prelude::UsbBusAllocator, UsbError};
 use usbd_serial::SerialPort;
@@ -85,20 +87,21 @@ pub struct UartConfigAndClock {
 type PicoUsbBusAllocator = UsbBusAllocator<UsbBus>;
 
 /// Initialize SWDIO, USB-UART, CMSIS-DAP and USB BUS.
-pub fn initialize_usb<'a, Swd, const MAX_PACKET_SIZE: usize>(
-    swdio: Swd,
+pub fn initialize_usb<'a, CmsisDapCommandInner, const MAX_PACKET_SIZE: usize>(
+    io: CmsisDapCommandInner,
     usb_allocator: &'a PicoUsbBusAllocator,
     serial: &'a str,
+    capabilities: DapCapabilities,
 ) -> (
     SerialPort<'a, UsbBus>,
-    CmsisDap<'a, UsbBus, Swd, MAX_PACKET_SIZE>,
+    CmsisDap<'a, UsbBus, CmsisDapCommandInner, MAX_PACKET_SIZE>,
     UsbDevice<'a, UsbBus>,
 )
 where
-    Swd: SwdIo,
+    CmsisDapCommandInner: rust_dap::CmsisDapCommandInner,
 {
     let usb_serial = SerialPort::new(usb_allocator);
-    let usb_dap = CmsisDap::new(usb_allocator, swdio);
+    let usb_dap = CmsisDap::new(usb_allocator, io, capabilities);
     let usb_bus = UsbDeviceBuilder::new(usb_allocator, UsbVidPid(0x6666, 0x4444))
         .manufacturer("fugafuga.org")
         .product("CMSIS-DAP")

--- a/rust-dap/Cargo.lock
+++ b/rust-dap/Cargo.lock
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "065681e99f9ef7e0e813702a0326aedbcbbde7db5e55f097aedd1bf50b9dca43"
+checksum = "9f6733da246dc2af610133c8be0667170fd68e8ca5630936b520300eee8846f9"
 dependencies = [
  "atomic-polyfill",
  "hash32",
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "riscv"
@@ -267,7 +267,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
- "semver 1.0.10",
+ "semver 1.0.12",
 ]
 
 [[package]]
@@ -287,9 +287,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.10"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41d061efea015927ac527063765e73601444cdc344ba855bc7bd44578b25e1c"
+checksum = "a2333e6df6d6598f2b1974829f853c2b4c5f4a6e503c10af918081aa6f8564e1"
 
 [[package]]
 name = "semver-parser"

--- a/rust-dap/src/bitbang.rs
+++ b/rust-dap/src/bitbang.rs
@@ -15,10 +15,88 @@
 // limitations under the License.
 
 use crate::cmsis_dap::*;
+use bitflags::bitflags;
 use embedded_hal::digital::v2::{InputPin, IoPin, OutputPin, PinState};
+
+// Bit 0: SWCLK/TCK
+// Bit 1: SWDIO/TMS
+// Bit 2: TDI
+// Bit 3: TDO
+// Bit 5: nTRST
+// Bit 7: nRESET
+// https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__SWJ__Pins.html
+bitflags! {
+    struct SwjPins: u8 {
+        const TCK_SWDCLK = 1;
+        const TMS_SWDIO = 1 << 1;
+        const TDI = 1 << 2;
+        const TDO = 1 << 3;
+        const N_TRST = 1 << 5;
+        const N_RESET = 1 << 7;
+    }
+}
 
 pub trait DelayFunc {
     fn cycle_delay(&self, cycles: u32);
+}
+
+fn turn_to_in<I: InputPin + IoPin<I, O>, O: OutputPin + IoPin<I, O>>(
+    pin_in: &mut Option<I>,
+    pin_out: &mut Option<O>,
+) {
+    let mut pin = None;
+    core::mem::swap(&mut pin, pin_out);
+    if let Some(pin_out) = pin {
+        *pin_in = Some(
+            pin_out
+                .into_input_pin()
+                .unwrap_or_else(|_| panic!("Failed to turn pin to input.")),
+        );
+    }
+}
+fn turn_to_out<I: InputPin + IoPin<I, O>, O: OutputPin + IoPin<I, O>>(
+    pin_in: &mut Option<I>,
+    pin_out: &mut Option<O>,
+    output: bool,
+) {
+    let mut pin = None;
+    core::mem::swap(&mut pin, pin_in);
+    if let Some(pin_in) = pin {
+        let state = if output {
+            PinState::High
+        } else {
+            PinState::Low
+        };
+        *pin_out = Some(
+            pin_in
+                .into_output_pin(state)
+                .unwrap_or_else(|_| panic!("Failed to turn pin to output.")),
+        );
+    }
+}
+
+fn set_output<I: InputPin + IoPin<I, O>, O: OutputPin + IoPin<I, O>>(
+    pin_out: &mut Option<O>,
+    output: bool,
+) {
+    pin_out.as_mut().and_then(|p| {
+        if output {
+            p.set_high().ok()
+        } else {
+            p.set_low().ok()
+        }
+    });
+}
+fn get_input<I: InputPin + IoPin<I, O>, O: OutputPin + IoPin<I, O>>(
+    pin_in: &mut Option<I>,
+) -> bool {
+    if let Some(pin_in) = pin_in {
+        pin_in
+            .is_high()
+            .unwrap_or_else(|_| panic!("Failed to get input pin is high"))
+    } else {
+        false
+    }
 }
 
 ///////////////////
@@ -523,4 +601,809 @@ where
         unimplemented!();
     }
 
+    fn jtag_idcode(
+        &self,
+        _config: &mut CmsisDapConfig,
+        _request: &[u8],
+        _response: &mut [u8],
+    ) -> core::result::Result<(usize, usize), DapError> {
+        Err(DapError::InvalidCommand)
+    }
+
+    fn jtag_sequence(
+        &mut self,
+        _config: &CmsisDapConfig,
+        _sequence_info: &JtagSequenceInfo,
+        _tdi_data: u64,
+    ) -> core::result::Result<Option<u64>, DapError> {
+        Err(DapError::InvalidCommand)
+    }
+}
+
+///////////////////
+/////// JTAG ///////
+///////////////////
+pub struct JtagIoSet<
+    TckInputPin,
+    TckOutputPin,
+    TmsInputPin,
+    TmsOutputPin,
+    TdiInputPin,
+    TdiOutputPin,
+    TdoInputPin,
+    TdoOutputPin,
+    TrstInputPin,
+    TrstOutputPin,
+    SrstInputPin,
+    SrstOutputPin,
+    DelayFn,
+> where
+    TckInputPin: InputPin + IoPin<TckInputPin, TckOutputPin>,
+    TckOutputPin: OutputPin + IoPin<TckInputPin, TckOutputPin>,
+    TmsInputPin: InputPin + IoPin<TmsInputPin, TmsOutputPin>,
+    TmsOutputPin: OutputPin + IoPin<TmsInputPin, TmsOutputPin>,
+    TdiInputPin: InputPin + IoPin<TdiInputPin, TdiOutputPin>,
+    TdiOutputPin: OutputPin + IoPin<TdiInputPin, TdiOutputPin>,
+    TdoInputPin: InputPin + IoPin<TdoInputPin, TdoOutputPin>,
+    TdoOutputPin: OutputPin + IoPin<TdoInputPin, TdoOutputPin>,
+    TrstInputPin: InputPin + IoPin<TrstInputPin, TrstOutputPin>,
+    TrstOutputPin: OutputPin + IoPin<TrstInputPin, TrstOutputPin>,
+    SrstInputPin: InputPin + IoPin<SrstInputPin, SrstOutputPin>,
+    SrstOutputPin: OutputPin + IoPin<SrstInputPin, SrstOutputPin>,
+    DelayFn: DelayFunc,
+{
+    tms_in: Option<TmsInputPin>,
+    tms_out: Option<TmsOutputPin>,
+    tck_in: Option<TckInputPin>,
+    tck_out: Option<TckOutputPin>,
+    tdi_in: Option<TdiInputPin>,
+    tdi_out: Option<TdiOutputPin>,
+    tdo_in: Option<TdoInputPin>,
+    tdo_out: Option<TdoOutputPin>,
+    ntrst_in: Option<TrstInputPin>,
+    ntrst_out: Option<TrstOutputPin>,
+    nsrst_in: Option<SrstInputPin>,
+    nsrst_out: Option<SrstOutputPin>,
+    cycle_delay: DelayFn,
+}
+
+impl<
+        TckInputPin,
+        TckOutputPin,
+        TmsInputPin,
+        TmsOutputPin,
+        TdiInputPin,
+        TdiOutputPin,
+        TdoInputPin,
+        TdoOutputPin,
+        TrstInputPin,
+        TrstOutputPin,
+        SrstInputPin,
+        SrstOutputPin,
+        DelayFn,
+    >
+    JtagIoSet<
+        TckInputPin,
+        TckOutputPin,
+        TmsInputPin,
+        TmsOutputPin,
+        TdiInputPin,
+        TdiOutputPin,
+        TdoInputPin,
+        TdoOutputPin,
+        TrstInputPin,
+        TrstOutputPin,
+        SrstInputPin,
+        SrstOutputPin,
+        DelayFn,
+    >
+where
+    TckInputPin: InputPin + IoPin<TckInputPin, TckOutputPin>,
+    TckOutputPin: OutputPin + IoPin<TckInputPin, TckOutputPin>,
+    TmsInputPin: InputPin + IoPin<TmsInputPin, TmsOutputPin>,
+    TmsOutputPin: OutputPin + IoPin<TmsInputPin, TmsOutputPin>,
+    TdiInputPin: InputPin + IoPin<TdiInputPin, TdiOutputPin>,
+    TdiOutputPin: OutputPin + IoPin<TdiInputPin, TdiOutputPin>,
+    TdoInputPin: InputPin + IoPin<TdoInputPin, TdoOutputPin>,
+    TdoOutputPin: OutputPin + IoPin<TdoInputPin, TdoOutputPin>,
+    TrstInputPin: InputPin + IoPin<TrstInputPin, TrstOutputPin>,
+    TrstOutputPin: OutputPin + IoPin<TrstInputPin, TrstOutputPin>,
+    SrstInputPin: InputPin + IoPin<SrstInputPin, SrstOutputPin>,
+    SrstOutputPin: OutputPin + IoPin<SrstInputPin, SrstOutputPin>,
+    DelayFn: DelayFunc,
+{
+    pub fn new(
+        tck: TckInputPin,
+        tms: TmsInputPin,
+        tdi: TdiInputPin,
+        tdo: TdoInputPin,
+        ntrst: TrstInputPin,
+        nsrst: SrstInputPin,
+        cycle_delay: DelayFn,
+    ) -> Self {
+        Self {
+            tms_in: Some(tms),
+            tms_out: None,
+            tck_in: Some(tck),
+            tck_out: None,
+            tdi_in: Some(tdi),
+            tdi_out: None,
+            tdo_in: Some(tdo),
+            tdo_out: None,
+            ntrst_in: Some(ntrst),
+            ntrst_out: None,
+            nsrst_in: Some(nsrst),
+            nsrst_out: None,
+            cycle_delay: cycle_delay,
+        }
+    }
+}
+
+impl<
+        TckInputPin,
+        TckOutputPin,
+        TmsInputPin,
+        TmsOutputPin,
+        TdiInputPin,
+        TdiOutputPin,
+        TdoInputPin,
+        TdoOutputPin,
+        TrstInputPin,
+        TrstOutputPin,
+        SrstInputPin,
+        SrstOutputPin,
+        DelayFn,
+    > BitBangJtagIo
+    for JtagIoSet<
+        TckInputPin,
+        TckOutputPin,
+        TmsInputPin,
+        TmsOutputPin,
+        TdiInputPin,
+        TdiOutputPin,
+        TdoInputPin,
+        TdoOutputPin,
+        TrstInputPin,
+        TrstOutputPin,
+        SrstInputPin,
+        SrstOutputPin,
+        DelayFn,
+    >
+where
+    TckInputPin: InputPin + IoPin<TckInputPin, TckOutputPin>,
+    TckOutputPin: OutputPin + IoPin<TckInputPin, TckOutputPin>,
+    TmsInputPin: InputPin + IoPin<TmsInputPin, TmsOutputPin>,
+    TmsOutputPin: OutputPin + IoPin<TmsInputPin, TmsOutputPin>,
+    TdiInputPin: InputPin + IoPin<TdiInputPin, TdiOutputPin>,
+    TdiOutputPin: OutputPin + IoPin<TdiInputPin, TdiOutputPin>,
+    TdoInputPin: InputPin + IoPin<TdoInputPin, TdoOutputPin>,
+    TdoOutputPin: OutputPin + IoPin<TdoInputPin, TdoOutputPin>,
+    TrstInputPin: InputPin + IoPin<TrstInputPin, TrstOutputPin>,
+    TrstOutputPin: OutputPin + IoPin<TrstInputPin, TrstOutputPin>,
+    SrstInputPin: InputPin + IoPin<SrstInputPin, SrstOutputPin>,
+    SrstOutputPin: OutputPin + IoPin<SrstInputPin, SrstOutputPin>,
+    DelayFn: DelayFunc,
+{
+    // TCK
+    fn to_tck_in(&mut self) {
+        turn_to_in(&mut self.tck_in, &mut self.tck_out);
+    }
+    fn to_tck_out(&mut self, output: bool) {
+        turn_to_out(&mut self.tck_in, &mut self.tck_out, output);
+    }
+    fn set_tck_output(&mut self, output: bool) {
+        set_output(&mut self.tck_out, output);
+    }
+    fn get_tck_input(&mut self) -> bool {
+        get_input(&mut self.tck_in)
+    }
+    // TMS
+    fn to_tms_in(&mut self) {
+        turn_to_in(&mut self.tms_in, &mut self.tms_out);
+    }
+    fn to_tms_out(&mut self, output: bool) {
+        turn_to_out(&mut self.tms_in, &mut self.tms_out, output);
+    }
+    fn set_tms_output(&mut self, output: bool) {
+        set_output(&mut self.tms_out, output);
+    }
+    fn get_tms_input(&mut self) -> bool {
+        get_input(&mut self.tms_in)
+    }
+    // TDI
+    fn to_tdi_in(&mut self) {
+        turn_to_in(&mut self.tdi_in, &mut self.tdi_out);
+    }
+    fn to_tdi_out(&mut self, output: bool) {
+        turn_to_out(&mut self.tdi_in, &mut self.tdi_out, output);
+    }
+    fn set_tdi_output(&mut self, output: bool) {
+        set_output(&mut self.tdi_out, output);
+    }
+    fn get_tdi_input(&mut self) -> bool {
+        get_input(&mut self.tdi_in)
+    }
+    // TDO
+    fn to_tdo_in(&mut self) {
+        turn_to_in(&mut self.tdo_in, &mut self.tdo_out);
+    }
+    fn to_tdo_out(&mut self, output: bool) {
+        turn_to_out(&mut self.tdo_in, &mut self.tdo_out, output);
+    }
+    fn set_tdo_output(&mut self, output: bool) {
+        set_output(&mut self.tdo_out, output);
+    }
+    fn get_tdo_input(&mut self) -> bool {
+        get_input(&mut self.tdo_in)
+    }
+    // nTRST
+    fn to_ntrst_in(&mut self) {
+        turn_to_in(&mut self.ntrst_in, &mut self.ntrst_out);
+    }
+    fn to_ntrst_out(&mut self, output: bool) {
+        turn_to_out(&mut self.ntrst_in, &mut self.ntrst_out, output);
+    }
+    fn set_ntrst_output(&mut self, output: bool) {
+        set_output(&mut self.ntrst_out, output);
+    }
+    fn get_ntrst_input(&mut self) -> bool {
+        get_input(&mut self.ntrst_in)
+    }
+    // nSRST
+    fn to_nsrst_in(&mut self) {
+        turn_to_in(&mut self.nsrst_in, &mut self.nsrst_out);
+    }
+    fn to_nsrst_out(&mut self, output: bool) {
+        turn_to_out(&mut self.nsrst_in, &mut self.nsrst_out, output);
+    }
+    fn set_nsrst_output(&mut self, output: bool) {
+        set_output(&mut self.nsrst_out, output);
+    }
+    fn get_nsrst_input(&mut self) -> bool {
+        get_input(&mut self.nsrst_in)
+    }
+    // delay
+    fn clock_wait(&self, config: &JtagIoConfig) {
+        self.cycle_delay.cycle_delay(config.clock_wait_cycles);
+    }
+}
+
+pub trait BitBangJtagIo {
+    // TCK
+    fn to_tck_in(&mut self);
+    fn to_tck_out(&mut self, output: bool);
+    fn set_tck_output(&mut self, output: bool);
+    fn get_tck_input(&mut self) -> bool;
+    // TMS
+    fn to_tms_in(&mut self);
+    fn to_tms_out(&mut self, output: bool);
+    fn set_tms_output(&mut self, output: bool);
+    fn get_tms_input(&mut self) -> bool;
+    // TDI
+    fn to_tdi_in(&mut self);
+    fn to_tdi_out(&mut self, output: bool);
+    fn set_tdi_output(&mut self, output: bool);
+    fn get_tdi_input(&mut self) -> bool;
+    // TDO
+    fn to_tdo_in(&mut self);
+    fn to_tdo_out(&mut self, output: bool);
+    fn set_tdo_output(&mut self, output: bool);
+    fn get_tdo_input(&mut self) -> bool;
+    // nTRST
+    fn to_ntrst_in(&mut self);
+    fn to_ntrst_out(&mut self, output: bool);
+    fn set_ntrst_output(&mut self, output: bool);
+    fn get_ntrst_input(&mut self) -> bool;
+    // nSRST
+    fn to_nsrst_in(&mut self);
+    fn to_nsrst_out(&mut self, output: bool);
+    fn set_nsrst_output(&mut self, output: bool);
+    fn get_nsrst_input(&mut self) -> bool;
+    // delay
+    fn clock_wait(&self, config: &JtagIoConfig);
+}
+
+pub trait PrimitiveJtagIo {
+    fn connect(&mut self, config: &JtagIoConfig);
+    fn disconnect(&mut self, config: &JtagIoConfig);
+    fn write_bit(&mut self, config: &JtagIoConfig, tms: bool, tdi: bool);
+    fn read_bit(&mut self, config: &JtagIoConfig, tms: bool, tdi: bool) -> bool;
+}
+
+impl<Io: BitBangJtagIo> PrimitiveJtagIo for Io {
+    fn connect(&mut self, config: &JtagIoConfig) {
+        // initial value
+        self.to_tck_out(false);
+        self.to_tms_out(false);
+        self.to_tdi_out(false);
+        self.to_tdo_in();
+        self.to_ntrst_out(true);
+        self.to_nsrst_out(true);
+
+        // reset with nTRST
+        // TODO: wait 1ms
+        self.set_ntrst_output(false);
+        self.clock_wait(config);
+        self.set_ntrst_output(true);
+        self.clock_wait(config);
+        // reset JTAG state machine
+        for _i in 0..10 {
+            self.write_bit(config, true, false);
+        }
+    }
+    fn disconnect(&mut self, config: &JtagIoConfig) {
+        // reset JTAG state machine
+        for _i in 0..10 {
+            self.write_bit(config, true, false);
+        }
+
+        self.to_tck_in();
+        self.to_tms_in();
+        self.to_tdi_in();
+        self.to_tdo_in();
+        self.to_ntrst_in();
+        self.to_nsrst_in();
+    }
+
+    fn write_bit(&mut self, config: &JtagIoConfig, tms: bool, tdi: bool) {
+        self.set_tms_output(tms);
+        self.set_tdi_output(tdi);
+        self.set_tck_output(false);
+        self.clock_wait(config);
+        self.set_tck_output(true);
+        self.clock_wait(config);
+    }
+
+    fn read_bit(&mut self, config: &JtagIoConfig, tms: bool, tdi: bool) -> bool {
+        self.set_tms_output(tms);
+        self.set_tdi_output(tdi);
+        self.set_tck_output(false);
+        self.clock_wait(config);
+        let value = self.get_tdo_input();
+        self.set_tck_output(true);
+        self.clock_wait(config);
+        value
+    }
+}
+
+impl<Io: PrimitiveJtagIo> JtagIo for Io {
+    fn connect(&mut self, config: &JtagIoConfig) {
+        PrimitiveJtagIo::connect(self, config)
+    }
+    fn disconnect(&mut self, config: &JtagIoConfig) {
+        PrimitiveJtagIo::disconnect(self, config)
+    }
+    fn swj_sequence(&mut self, config: &JtagIoConfig, count: usize, data: &[u8]) {
+        // https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__SWJ__Sequence.html
+        let mut index = 0;
+        let mut value = 0;
+        let mut bits = 0;
+        let mut count = count;
+        while count > 0 {
+            count -= 1;
+            if bits == 0 {
+                value = data[index];
+                index += 1;
+                bits = 8;
+            }
+            self.write_bit(config, value & 1 != 0, false);
+            value >>= 1;
+            bits -= 1;
+        }
+    }
+    fn jtag_read_sequence(
+        &mut self,
+        config: &JtagIoConfig,
+        clock_count: usize,
+        tms_value: bool,
+        tdi_data: u64,
+    ) -> u64 {
+        let tdi_data = tdi_data;
+        let mut tdo_data = 0;
+        for i in 0..clock_count {
+            assert!(clock_count <= 64);
+            let tdo = self.read_bit(config, tms_value, (tdi_data & (1 << i)) != 0);
+            tdo_data |= if tdo { 1 } else { 0 } << i;
+        }
+        tdo_data
+    }
+
+    fn jtag_write_sequence(
+        &mut self,
+        config: &JtagIoConfig,
+        clock_count: usize,
+        tms_value: bool,
+        tdi_data: u64,
+    ) {
+        let tdi_data = tdi_data;
+        for i in 0..clock_count {
+            self.write_bit(config, tms_value, (tdi_data & (1 << i)) != 0);
+        }
+    }
+
+    fn jtag_idcode(
+        &mut self,
+        _config: &JtagIoConfig,
+        _index: u8,
+    ) -> core::result::Result<u32, DapError> {
+        // https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__jtag__idcode.html#details
+        unimplemented!();
+    }
+
+    fn write_ir(&mut self, config: &JtagIoConfig, dap_index: u8, ir: u32) {
+        // to ShiftIR from Run-Test-Idle
+        self.write_bit(config, true, false); // SelectDR
+        self.write_bit(config, true, false); // SelectIR
+        self.write_bit(config, false, false); // CaptureIR
+        self.write_bit(config, false, false); // ShiftIR
+
+        // dap_indexの示すIRレジスタ以外はBYPASS(all 1)にする
+        let device_count = config.device_count;
+        let ir_length = &config.ir_length[0..(device_count as usize)];
+        let bit_count_max = ir_length.iter().map(|x| *x as usize).sum();
+        let mut bit_count: usize = 0;
+        let mut ir = ir;
+        for (i, length) in ir_length.iter().enumerate().rev() {
+            for _j in 0..*length {
+                let tdi = if i == (dap_index as usize) {
+                    let bit = (ir & 1) != 0;
+                    ir >>= 1;
+                    bit
+                } else {
+                    true
+                };
+                bit_count += 1;
+                // last 1bit は TMS を true にしてExit-IRにする
+                let tms = bit_count == bit_count_max;
+                self.write_bit(config, tms, tdi);
+            }
+        }
+
+        // to Run from Exit-IR
+        self.write_bit(config, true, false); // Update-IR
+        self.write_bit(config, false, false); // Run
+    }
+
+    fn write_dr(&mut self, config: &JtagIoConfig, dap_index: u8, dr: &[bool]) {
+        if dr.is_empty() {
+            // TODO: return Err
+            panic!("dr have to hold least 1 bit")
+        }
+        // to ShiftIR from Run-Test-Idle
+        self.write_bit(config, true, false); // SelectDR
+        self.write_bit(config, false, false); // CaptureDR
+        self.write_bit(config, false, false); // ShiftDR
+
+        let head_bits = config.ir_length[0..(config.device_count as usize)]
+            .iter()
+            .take(dap_index.into())
+            .map(|x| *x as usize)
+            .sum();
+        let tail_bits = config.ir_length[0..(config.device_count as usize)]
+            .iter()
+            .skip(dap_index as usize + 1)
+            .map(|x| *x as usize)
+            .sum();
+        let total_bits = config.ir_length[0..(config.device_count as usize)]
+            .iter()
+            .map(|x| *x as usize)
+            .sum();
+        let mut bit_count: usize = 0;
+        for _i in 0..tail_bits {
+            // dap_index以降のDR用
+            bit_count += 1;
+            self.write_bit(config, false, false);
+        }
+        for dr_bit in dr {
+            bit_count += 1;
+            let tms = bit_count == total_bits;
+            self.write_bit(config, tms, *dr_bit);
+        }
+        for _i in 0..head_bits {
+            bit_count += 1;
+            let tms = bit_count == total_bits;
+            self.write_bit(config, tms, false);
+        }
+
+        // to Run from Exit-DR
+        self.write_bit(config, true, false); // Update-DR
+        self.write_bit(config, false, false); // Run
+    }
+
+    fn read_write_dr(&mut self, config: &JtagIoConfig, dap_index: u8, dr: &mut [bool]) {
+        // to ShiftIR from Run-Test-Idle
+        self.write_bit(config, true, false); // SelectDR
+        self.write_bit(config, false, false); // CaptureDR
+        self.write_bit(config, false, false); // ShiftDR
+
+        // DRの内容を取得する
+        let head_bits = config.ir_length[0..(config.device_count as usize)]
+            .iter()
+            .take(dap_index.into())
+            .map(|x| *x as usize)
+            .sum();
+        let tail_bits = config.ir_length[0..(config.device_count as usize)]
+            .iter()
+            .skip(dap_index as usize + 1)
+            .map(|x| *x as usize)
+            .sum();
+        let total_bits = config.ir_length[0..(config.device_count as usize)]
+            .iter()
+            .map(|x| *x as usize)
+            .sum();
+        let mut bit_count: usize = 0;
+        for _i in 0..tail_bits {
+            // dap_index以降のDR用
+            bit_count += 1;
+            self.write_bit(config, false, false);
+        }
+        for dr_bit in dr {
+            bit_count += 1;
+            let tms = bit_count == total_bits;
+            let tdo = self.read_bit(config, tms, *dr_bit);
+            *dr_bit = tdo;
+        }
+        for _i in 0..head_bits {
+            bit_count += 1;
+            let tms = bit_count == total_bits;
+            self.write_bit(config, tms, false);
+        }
+
+        // to Run from Exit-DR
+        self.write_bit(config, true, false); // Update-DR
+        self.write_bit(config, false, false); // Run
+    }
+
+    fn jtag_transfer(
+        &mut self,
+        config: &JtagIoConfig,
+        dap_index: u8,
+        request: SwdRequest,
+        data: u32,
+    ) -> core::result::Result<u32, DapError> {
+        // https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__Transfer.html
+        // JTAGを使ってDAPとの送受信をやる
+
+        let instruction = if request.contains(SwdRequest::APnDP) {
+            // APACC
+            JtagInstruction::APACC as u32
+        } else {
+            // DPACC
+            JtagInstruction::DPACC as u32
+        };
+        let read = request.contains(SwdRequest::RnW);
+        let a2 = request.contains(SwdRequest::A2);
+        let a3 = request.contains(SwdRequest::A3);
+
+        // DPACCかAPACCを発行する
+        self.write_ir(config, dap_index, instruction);
+        // DRを書き込む
+        if read {
+            let mut dr = build_acc(data, a3, a2, true);
+            self.read_write_dr(config, dap_index, &mut dr);
+            // TODO: OK_FALSE等の情報を返す必要がないか調べる
+            let dr_data = &dr[3..35];
+            let mut result: u32 = 0;
+            for (i, dr) in dr_data.iter().enumerate().take(32) {
+                result |= if *dr { 1 << i } else { 0 };
+            }
+            Ok(result)
+        } else {
+            let dr = build_acc(data, a3, a2, false);
+            self.write_dr(config, dap_index, &dr);
+            Ok(0)
+        }
+    }
+}
+
+fn build_acc(data: u32, a3: bool, a2: bool, read: bool) -> [bool; 35] {
+    let mut data = data;
+    let mut dr = [false; 35];
+    dr[0] = read;
+    dr[1] = a2;
+    dr[2] = a3;
+    for i in 0..32 {
+        dr[3 + i] = (data & 1) != 0;
+        data >>= 1;
+    }
+    dr
+}
+
+#[allow(dead_code)]
+enum JtagInstruction {
+    ABORT = 0b1000,
+    DPACC = 0b1010,
+    APACC = 0b1011,
+    IDCODE = 0b1110,
+    BYPASS = 0b1111,
+}
+
+impl<
+        TckInputPin,
+        TckOutputPin,
+        TmsInputPin,
+        TmsOutputPin,
+        TdiInputPin,
+        TdiOutputPin,
+        TdoInputPin,
+        TdoOutputPin,
+        TrstInputPin,
+        TrstOutputPin,
+        SrstInputPin,
+        SrstOutputPin,
+        DelayFn,
+    > CmsisDapCommandInner
+    for JtagIoSet<
+        TckInputPin,
+        TckOutputPin,
+        TmsInputPin,
+        TmsOutputPin,
+        TdiInputPin,
+        TdiOutputPin,
+        TdoInputPin,
+        TdoOutputPin,
+        TrstInputPin,
+        TrstOutputPin,
+        SrstInputPin,
+        SrstOutputPin,
+        DelayFn,
+    >
+where
+    TckInputPin: InputPin + IoPin<TckInputPin, TckOutputPin>,
+    TckOutputPin: OutputPin + IoPin<TckInputPin, TckOutputPin>,
+    TmsInputPin: InputPin + IoPin<TmsInputPin, TmsOutputPin>,
+    TmsOutputPin: OutputPin + IoPin<TmsInputPin, TmsOutputPin>,
+    TdiInputPin: InputPin + IoPin<TdiInputPin, TdiOutputPin>,
+    TdiOutputPin: OutputPin + IoPin<TdiInputPin, TdiOutputPin>,
+    TdoInputPin: InputPin + IoPin<TdoInputPin, TdoOutputPin>,
+    TdoOutputPin: OutputPin + IoPin<TdoInputPin, TdoOutputPin>,
+    TrstInputPin: InputPin + IoPin<TrstInputPin, TrstOutputPin>,
+    TrstOutputPin: OutputPin + IoPin<TrstInputPin, TrstOutputPin>,
+    SrstInputPin: InputPin + IoPin<SrstInputPin, SrstOutputPin>,
+    SrstOutputPin: OutputPin + IoPin<SrstInputPin, SrstOutputPin>,
+    DelayFn: DelayFunc,
+{
+    fn connect(&mut self, config: &CmsisDapConfig) {
+        JtagIo::connect(self, &config.jtag);
+    }
+    fn disconnect(&mut self, config: &CmsisDapConfig) {
+        JtagIo::disconnect(self, &config.jtag);
+    }
+
+    fn swj_sequence(&mut self, config: &CmsisDapConfig, count: usize, data: &[u8]) {
+        JtagIo::swj_sequence(self, &config.jtag, count, data);
+    }
+
+    fn swd_sequence(
+        &mut self,
+        _config: &CmsisDapConfig,
+        _request: &[u8],
+        _response: &mut [u8],
+    ) -> core::result::Result<(usize, usize), DapError> {
+        Err(DapError::InvalidCommand)
+    }
+
+    fn jtag_sequence(
+        &mut self,
+        config: &CmsisDapConfig,
+        sequence_info: &JtagSequenceInfo,
+        tdi_data: u64,
+    ) -> core::result::Result<Option<u64>, DapError> {
+        Ok(if sequence_info.tdo_capture {
+            Some(JtagIo::jtag_read_sequence(
+                self,
+                &config.jtag,
+                sequence_info.number_of_tck_cycles,
+                sequence_info.tms_value,
+                tdi_data,
+            ))
+        } else {
+            JtagIo::jtag_write_sequence(
+                self,
+                &config.jtag,
+                sequence_info.number_of_tck_cycles,
+                sequence_info.tms_value,
+                tdi_data,
+            );
+            None
+        })
+    }
+
+    fn transfer_inner_with_retry(
+        &mut self,
+        config: &CmsisDapConfig,
+        dap_index: u8,
+        request: SwdRequest,
+        data: u32,
+    ) -> core::result::Result<u32, DapError> {
+        let mut retry_count = 0;
+        loop {
+            match JtagIo::jtag_transfer(self, &config.jtag, dap_index, request, data) {
+                Ok(value) => break Ok(value),
+                Err(DapError::SwdError(err)) => {
+                    // TODO: 動作確認
+                    if err != DAP_TRANSFER_WAIT || retry_count == config.retry_count {
+                        break Err(DapError::SwdError(err));
+                    }
+                    retry_count += 1;
+                }
+                Err(err) => break Err(err),
+            }
+        }
+    }
+    fn swj_pins(
+        &mut self,
+        _config: &CmsisDapConfig,
+        pin_output: u8,
+        pin_select: u8,
+        _wait_us: u32,
+    ) -> core::result::Result<u8, DapError> {
+        let pin_output = SwjPins::from_bits(pin_output).unwrap();
+        let pin_select = SwjPins::from_bits(pin_select).unwrap();
+
+        let flags = [
+            SwjPins::TCK_SWDCLK,
+            SwjPins::TMS_SWDIO,
+            SwjPins::TDI,
+            SwjPins::TDO,
+            SwjPins::N_TRST,
+            SwjPins::N_RESET,
+        ];
+
+        // output
+        for f in flags {
+            if pin_select.contains(f) {
+                let output = pin_output.contains(f);
+                match f {
+                    SwjPins::TCK_SWDCLK => self.set_tck_output(output),
+                    SwjPins::TMS_SWDIO => self.set_tms_output(output),
+                    SwjPins::TDI => self.set_tdi_output(output),
+                    SwjPins::TDO => self.set_tdo_output(output),
+                    SwjPins::N_TRST => self.set_ntrst_output(output),
+                    SwjPins::N_RESET => self.set_nsrst_output(output),
+                    _ => (),
+                }
+            }
+        }
+
+        // TODO: support wait_us
+
+        // input
+        let mut pin_input = if self.get_tck_input() {
+            SwjPins::TCK_SWDCLK
+        } else {
+            SwjPins::empty()
+        };
+        pin_input |= if self.get_tms_input() {
+            SwjPins::TMS_SWDIO
+        } else {
+            SwjPins::empty()
+        };
+        pin_input |= if self.get_tdi_input() {
+            SwjPins::TDI
+        } else {
+            SwjPins::empty()
+        };
+        pin_input |= if self.get_ntrst_input() {
+            SwjPins::N_TRST
+        } else {
+            SwjPins::empty()
+        };
+        pin_input |= if self.get_nsrst_input() {
+            SwjPins::N_RESET
+        } else {
+            SwjPins::empty()
+        };
+
+        Ok(pin_input.bits())
+    }
+
+    fn jtag_idcode(
+        &self,
+        _config: &mut CmsisDapConfig,
+        _request: &[u8],
+        _response: &mut [u8],
+    ) -> core::result::Result<(usize, usize), DapError> {
+        unimplemented!();
+    }
 }

--- a/rust-dap/src/bitbang.rs
+++ b/rust-dap/src/bitbang.rs
@@ -598,7 +598,8 @@ where
         _pin_select: u8,
         _wait_us: u32,
     ) -> core::result::Result<u8, DapError> {
-        unimplemented!();
+        // TODO: write
+        Ok(0)
     }
 
     fn jtag_idcode(

--- a/rust-dap/src/cmsis_dap.rs
+++ b/rust-dap/src/cmsis_dap.rs
@@ -885,21 +885,21 @@ mod test {
             todo!()
         }
 
-        fn swj_sequence(&mut self, config: &SwdIoConfig, count: usize, data: &[u8]) {
+        fn swj_sequence(&mut self, _config: &SwdIoConfig, _count: usize, _data: &[u8]) {
             todo!()
         }
 
-        fn swd_read_sequence(&mut self, config: &SwdIoConfig, count: usize, data: &mut [u8]) {}
+        fn swd_read_sequence(&mut self, _config: &SwdIoConfig, _count: usize, _data: &mut [u8]) {}
 
-        fn swd_write_sequence(&mut self, config: &SwdIoConfig, count: usize, data: &[u8]) {
+        fn swd_write_sequence(&mut self, _config: &SwdIoConfig, _count: usize, _data: &[u8]) {
             todo!()
         }
 
         fn swd_transfer(
             &mut self,
-            config: &SwdIoConfig,
-            request: SwdRequest,
-            data: u32,
+            _config: &SwdIoConfig,
+            _request: SwdRequest,
+            _data: u32,
         ) -> core::result::Result<u32, DapError> {
             todo!()
         }
@@ -917,11 +917,11 @@ mod test {
     impl UsbBus for DummyUsbInterface {
         fn alloc_ep(
             &mut self,
-            ep_dir: usb_device::UsbDirection,
-            ep_addr: Option<EndpointAddress>,
-            ep_type: EndpointType,
-            max_packet_size: u16,
-            interval: u8,
+            _ep_dir: usb_device::UsbDirection,
+            _ep_addr: Option<EndpointAddress>,
+            _ep_type: EndpointType,
+            _max_packet_size: u16,
+            _interval: u8,
         ) -> Result<EndpointAddress> {
             Ok(EndpointAddress::from(0))
         }
@@ -932,25 +932,25 @@ mod test {
             todo!()
         }
 
-        fn set_device_address(&self, addr: u8) {
+        fn set_device_address(&self, _addr: u8) {
             todo!()
         }
 
-        fn write(&self, ep_addr: EndpointAddress, buf: &[u8]) -> Result<usize> {
+        fn write(&self, _ep_addr: EndpointAddress, buf: &[u8]) -> Result<usize> {
             Ok(buf.len())
         }
 
-        fn read(&self, ep_addr: EndpointAddress, buf: &mut [u8]) -> Result<usize> {
+        fn read(&self, _ep_addr: EndpointAddress, buf: &mut [u8]) -> Result<usize> {
             buf[..self.read_buffer_size]
                 .clone_from_slice(&self.read_buffer[..self.read_buffer_size]);
             Ok(self.read_buffer_size)
         }
 
-        fn set_stalled(&self, ep_addr: EndpointAddress, stalled: bool) {
+        fn set_stalled(&self, _ep_addr: EndpointAddress, _stalled: bool) {
             todo!()
         }
 
-        fn is_stalled(&self, ep_addr: EndpointAddress) -> bool {
+        fn is_stalled(&self, _ep_addr: EndpointAddress) -> bool {
             todo!()
         }
 

--- a/rust-dap/src/lib.rs
+++ b/rust-dap/src/lib.rs
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 
 #[cfg(feature = "bitbang")]
 pub mod bitbang;


### PR DESCRIPTION
# やりたいこと

- JTAGをサポートしたい

# やったこと

- CmsisDapを分割してInterfaceを入れ替えられるようにした
- bitbangモードでJtag interfaceをサポートした

# 動作確認方法

## JTAG

1. `boards/rpi_pico` ディレクトリ以下にて `cargo run --features jtag` でビルドしたコードをRaspberry Pi Picoに書き込む
2. `boards/rpi_pico/src/main.rs` のピン定義を参考に、JTAG接続可能なデバイスのJTAGポートに接続する
    - IO11 -> TMS
    - IO18 -> TCK
    - IO10 -> TDI
    - IO19 -> TDO
    - IO9 -> nTRST
    - IO20 -> nSRST
3. `openocd -f interface/cmsis-dap.cfg -f <board name>.cfg` のようにしてOpenOCDを立ち上げる
4. `telnet localhost 4444` でopenocdに接続し、`reg` コマンドでレジスタ一覧が表示されるのを確認する

## SWD

### bitbang

1. `boards/rpi_pico` ディレクトリ以下にて `cargo run --features swd,bitbang` でビルドしたコードをRaspberry Pi Picoに書き込む
2. デバッグ対象のPicoをもう1台用意し、IOとSWDを接続する
3. openocdを動かし、DPが見つかるのを確認する

```
openocd -f interface/cmsis-dap.cfg \
-c 'transport select swd' \
-c 'adapter speed 1000' \
-c 'swd newdap rp2040.core0 cpu -dp-id 0x01002927 -instance-id 0' \
-c 'dap create rp2040_0.dap -chain-position rp2040.core0.cpu'
```

### pio

`cargo run --features swd` でビルドする以外はbitbangと同様。

<s>（私の環境ではPIOがうまくテストできないため、未検証です）</s> PIOも動きました