### PR TITLE
JTAGで使うGPIOポートをrust-dapデバッグポートに合わせてSWDと共通化したい

### DIFF
--- a/boards/rpi_pico/src/main.rs
+++ b/boards/rpi_pico/src/main.rs
@@ -70,17 +70,17 @@ mod app {
     type GpioSwdIo = hal::gpio::bank0::Gpio3;
     // jtag
     #[cfg(feature = "jtag")]
-    type JtagTmsPin = hal::gpio::bank0::Gpio11;
+    type JtagTckPin = hal::gpio::bank0::Gpio2;
     #[cfg(feature = "jtag")]
-    type JtagTckPin = hal::gpio::bank0::Gpio18;
+    type JtagTmsPin = hal::gpio::bank0::Gpio3;
     #[cfg(feature = "jtag")]
-    type JtagTdiPin = hal::gpio::bank0::Gpio10;
+    type JtagTdoPin = hal::gpio::bank0::Gpio5;
     #[cfg(feature = "jtag")]
-    type JtagTdoPin = hal::gpio::bank0::Gpio19;
+    type JtagTdiPin = hal::gpio::bank0::Gpio6;
     #[cfg(feature = "jtag")]
-    type JtagTrstPin = hal::gpio::bank0::Gpio9;
+    type JtagTrstPin = hal::gpio::bank0::Gpio7;
     #[cfg(feature = "jtag")]
-    type JtagResetPin = hal::gpio::bank0::Gpio20;
+    type JtagResetPin = hal::gpio::bank0::Gpio4;
 
     // UART Interrupt context
     const UART_RX_QUEUE_SIZE: usize = 256;
@@ -218,12 +218,12 @@ mod app {
             #[cfg(feature = "bitbang")]
             {
                 use rust_dap_rp2040::{swdio_pin::PicoSwdInputPin, util::CycleDelay};
-                let tck_pin = PicoSwdInputPin::new(pins.gpio18.into_floating_input());
-                let tms_pin = PicoSwdInputPin::new(pins.gpio11.into_floating_input());
-                let tdi_pin = PicoSwdInputPin::new(pins.gpio10.into_floating_input());
-                let tdo_pin = PicoSwdInputPin::new(pins.gpio19.into_floating_input());
-                let trst_pin = PicoSwdInputPin::new(pins.gpio9.into_floating_input());
-                let srst_pin = PicoSwdInputPin::new(pins.gpio20.into_floating_input());
+                let tck_pin = PicoSwdInputPin::new(pins.gpio2.into_floating_input());
+                let tms_pin = PicoSwdInputPin::new(pins.gpio3.into_floating_input());
+                let tdo_pin = PicoSwdInputPin::new(pins.gpio5.into_floating_input());
+                let tdi_pin = PicoSwdInputPin::new(pins.gpio6.into_floating_input());
+                let trst_pin = PicoSwdInputPin::new(pins.gpio7.into_floating_input());
+                let srst_pin = PicoSwdInputPin::new(pins.gpio4.into_floating_input());
                 jtagio = JtagIoSet::new(
                     tck_pin,
                     tms_pin,

--- a/boards/rpi_pico/src/main.rs
+++ b/boards/rpi_pico/src/main.rs
@@ -60,7 +60,7 @@ mod app {
     type GpioUartRx = hal::gpio::bank0::Gpio1;
     type GpioUsbLed = hal::gpio::bank0::Gpio25;
     type GpioIdleLed = hal::gpio::bank0::Gpio17;
-    type GpioDebugOut = hal::gpio::bank0::Gpio6;
+    type GpioDebugOut = hal::gpio::bank0::Gpio15;
     type GpioDebugIrqOut = hal::gpio::bank0::Gpio28;
     type GpioDebugUsbIrqOut = hal::gpio::bank0::Gpio27;
     // swd
@@ -246,7 +246,7 @@ mod app {
         let (uart_rx_producer, uart_rx_consumer) = c.local.uart_rx_queue.split();
         let (uart_tx_producer, uart_tx_consumer) = c.local.uart_tx_queue.split();
 
-        let mut debug_out = pins.gpio6.into_push_pull_output();
+        let mut debug_out = pins.gpio15.into_push_pull_output();
         debug_out.set_low().ok();
         let mut debug_irq_out = pins.gpio28.into_push_pull_output();
         debug_irq_out.set_low().ok();


### PR DESCRIPTION
# やりたいこと

SWDとJTAGのGPIOピン割当が異なると両機能のデバッグ時に不便なので、以下の基板のピン配置に合わせたい
https://github.com/ciniml/rust-dap/issues/28#issuecomment-1179554978

# やったこと

JTAGのGPIOピン割当をrust-dapデバッグボードのピン割当に合わせた

# 動作確認方法

rust-dapデバッグボードでswdとjtag両方の動作を確認する