### PR TITLE
PIOで減算オーバーフローが発生していたので修正

### DIFF
--- a/rust-dap-rp2040/src/pio.rs
+++ b/rust-dap-rp2040/src/pio.rs
@@ -214,7 +214,8 @@ impl<C, D> SwdIoSet<C, D> {
         while !self.tx_fifo.write(bits | 0) {}
         while self.rx_fifo.is_empty() {}
         let value = unsafe { self.rx_fifo.read().unwrap_unchecked() };
-        value >> ((32 - bits) & 31)
+        // next line means this: value >> ((32 - bits) & 31)
+        value.wrapping_shr(bits.wrapping_neg())
     }
 }
 


### PR DESCRIPTION
@tnishinaga さんの指摘で気付きました。

PIO で panic が発生する箇所があったので修正しました。

気付いていなかったのは、最適化ありの release ビルドしか試していなかったからです。

~~最適化によって 軽微な？整合性チェックの panic は、消えてしまうんですね。~~

マージ順は、後回しでよいと思います。