### PR TITLE
swj_clockによるクロック周波数設定の実装

### DIFF
--- a/boards/rpi_pico/Cargo.toml
+++ b/boards/rpi_pico/Cargo.toml
@@ -15,7 +15,7 @@ bitbang = ["rust-dap/bitbang", "rust-dap-rp2040/bitbang"]
 
 [dependencies]
 rust-dap = { path = "../../rust-dap", features = ["unproven"] }
-rust-dap-rp2040 = { path = "../../rust-dap-rp2040" }
+rust-dap-rp2040 = { path = "../../rust-dap-rp2040", features = ["pio_set_clock"] }
 rp-pico = { git = "https://github.com/rp-rs/rp-hal.git", rev = "8d18abdfc7c0129debba85457d32d32175bf36bd" }
 panic-halt = "0.2"
 cortex-m = "0.7"

--- a/boards/rpi_pico/Cargo.toml
+++ b/boards/rpi_pico/Cargo.toml
@@ -12,6 +12,7 @@ debug = 2
 
 [features]
 bitbang = ["rust-dap/bitbang", "rust-dap-rp2040/bitbang"]
+pio_set_clock = ["rust-dap-rp2040/pio_set_clock"]   # Enable swj_clock implementation for PIO and set appropriate SWCLK frequency. Otherwise, SWCLK is fixed to 15.625[MHz]
 
 [dependencies]
 rust-dap = { path = "../../rust-dap", features = ["unproven"] }

--- a/boards/rpi_pico/Cargo.toml
+++ b/boards/rpi_pico/Cargo.toml
@@ -12,14 +12,14 @@ debug = 2
 
 [features]
 bitbang = ["rust-dap/bitbang", "rust-dap-rp2040/bitbang"]
-pio_set_clock = ["rust-dap-rp2040/pio_set_clock"]   # Enable swj_clock implementation for PIO and set appropriate SWCLK frequency. Otherwise, SWCLK is fixed to 15.625[MHz]
+set_clock = ["rust-dap-rp2040/set_clock"]   # Enable swj_clock implementation for PIO and set appropriate SWCLK frequency. Otherwise, SWCLK is fixed to 15.625[MHz]
 jtag = ["bitbang"]
 swd = []
 swj = []
 
 [dependencies]
 rust-dap = { path = "../../rust-dap", features = ["unproven"] }
-rust-dap-rp2040 = { path = "../../rust-dap-rp2040", features = ["pio_set_clock"] }
+rust-dap-rp2040 = { path = "../../rust-dap-rp2040", features = [] }
 rp-pico = { git = "https://github.com/rp-rs/rp-hal.git", rev = "8d18abdfc7c0129debba85457d32d32175bf36bd" }
 panic-halt = "0.2"
 cortex-m = "0.7"

--- a/boards/xiao_m0/src/main.rs
+++ b/boards/xiao_m0/src/main.rs
@@ -20,10 +20,7 @@
 use embedded_hal::digital::v2::ToggleableOutputPin;
 use panic_halt as _;
 use rust_dap::bitbang::{DelayFunc, SwdIoSet};
-use rust_dap::DapCapabilities;
-use rust_dap::USB_CLASS_MISCELLANEOUS;
-use rust_dap::USB_PROTOCOL_IAD;
-use rust_dap::USB_SUBCLASS_COMMON;
+use rust_dap::{CmsisDap, DapCapabilities, USB_CLASS_MISCELLANEOUS, USB_PROTOCOL_IAD, USB_SUBCLASS_COMMON};
 
 use bsp::{entry, hal, pac};
 use hal::clock::GenericClockController;
@@ -34,7 +31,6 @@ use xiao_m0 as bsp;
 use usb_device::bus::UsbBusAllocator;
 use xiao_m0::hal::usb::UsbBus;
 
-use rust_dap::{CmsisDap, DapCapabilities};
 use usb_device::prelude::*;
 use usbd_serial::SerialPort;
 

--- a/boards/xiao_m0/src/main.rs
+++ b/boards/xiao_m0/src/main.rs
@@ -20,7 +20,9 @@
 use embedded_hal::digital::v2::ToggleableOutputPin;
 use panic_halt as _;
 use rust_dap::bitbang::{DelayFunc, SwdIoSet};
-use rust_dap::{CmsisDap, DapCapabilities, USB_CLASS_MISCELLANEOUS, USB_PROTOCOL_IAD, USB_SUBCLASS_COMMON};
+use rust_dap::{
+    CmsisDap, DapCapabilities, USB_CLASS_MISCELLANEOUS, USB_PROTOCOL_IAD, USB_SUBCLASS_COMMON,
+};
 
 use bsp::{entry, hal, pac};
 use hal::clock::GenericClockController;

--- a/boards/xiao_m0/src/main.rs
+++ b/boards/xiao_m0/src/main.rs
@@ -34,7 +34,7 @@ use xiao_m0 as bsp;
 use usb_device::bus::UsbBusAllocator;
 use xiao_m0::hal::usb::UsbBus;
 
-use rust_dap::CmsisDap;
+use rust_dap::{CmsisDap, DapCapabilities};
 use usb_device::prelude::*;
 use usbd_serial::SerialPort;
 
@@ -96,7 +96,7 @@ fn main() -> ! {
 
     unsafe {
         USB_SERIAL = Some(SerialPort::new(&bus_allocator));
-        USB_DAP = Some(CmsisDap::new(&bus_allocator, swdio));
+        USB_DAP = Some(CmsisDap::new(&bus_allocator, swdio, DapCapabilities::SWD));
         USB_BUS = Some(
             UsbDeviceBuilder::new(&bus_allocator, UsbVidPid(0x6666, 0x4444))
                 .manufacturer("fugafuga.org")

--- a/boards/xiao_rp2040/Cargo.toml
+++ b/boards/xiao_rp2040/Cargo.toml
@@ -12,7 +12,7 @@ debug = 2
 
 [features]
 bitbang = ["rust-dap/bitbang", "rust-dap-rp2040/bitbang"]
-pio_set_clock = ["rust-dap-rp2040/pio_set_clock"]   # Enable swj_clock implementation for PIO and set appropriate SWCLK frequency. Otherwise, SWCLK is fixed to 15.625[MHz]
+set_clock = ["rust-dap-rp2040/set_clock"]   # Enable swj_clock implementation for PIO and set appropriate SWCLK frequency. Otherwise, SWCLK is fixed to 15.625[MHz]
 
 [dependencies]
 rust-dap = { path = "../../rust-dap", features = ["unproven"] }

--- a/boards/xiao_rp2040/Cargo.toml
+++ b/boards/xiao_rp2040/Cargo.toml
@@ -12,6 +12,7 @@ debug = 2
 
 [features]
 bitbang = ["rust-dap/bitbang", "rust-dap-rp2040/bitbang"]
+pio_set_clock = ["rust-dap-rp2040/pio_set_clock"]   # Enable swj_clock implementation for PIO and set appropriate SWCLK frequency. Otherwise, SWCLK is fixed to 15.625[MHz]
 
 [dependencies]
 rust-dap = { path = "../../rust-dap", features = ["unproven"] }

--- a/boards/xiao_rp2040/src/main.rs
+++ b/boards/xiao_rp2040/src/main.rs
@@ -28,7 +28,7 @@ mod app {
     use hal::usb::UsbBus;
     use usb_device::bus::UsbBusAllocator;
 
-    use rust_dap::CmsisDap;
+    use rust_dap::{CmsisDap, DapCapabilities};
     use usb_device::prelude::*;
     use usbd_serial::SerialPort;
 
@@ -170,7 +170,7 @@ mod app {
             swdio_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
             swdio = SwdIoSet::new(c.device.PIO0, swclk_pin, swdio_pin, &mut resets);
         }
-        let (usb_serial, usb_dap, usb_bus) = initialize_usb(swdio, usb_allocator, "xiao-rp2040");
+        let (usb_serial, usb_dap, usb_bus) = initialize_usb(swdio, usb_allocator, "xiao-rp2040", DapCapabilities::SWD);
 
         let usb_led = pins.led.into_push_pull_output();
         let (uart_rx_producer, uart_rx_consumer) = c.local.uart_rx_queue.split();

--- a/boards/xiao_rp2040/src/main.rs
+++ b/boards/xiao_rp2040/src/main.rs
@@ -170,7 +170,8 @@ mod app {
             swdio_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
             swdio = SwdIoSet::new(c.device.PIO0, swclk_pin, swdio_pin, &mut resets);
         }
-        let (usb_serial, usb_dap, usb_bus) = initialize_usb(swdio, usb_allocator, "xiao-rp2040", DapCapabilities::SWD);
+        let (usb_serial, usb_dap, usb_bus) =
+            initialize_usb(swdio, usb_allocator, "xiao-rp2040", DapCapabilities::SWD);
 
         let usb_led = pins.led.into_push_pull_output();
         let (uart_rx_producer, uart_rx_consumer) = c.local.uart_rx_queue.split();

--- a/rust-dap-rp2040/Cargo.toml
+++ b/rust-dap-rp2040/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 
 [features]
 bitbang = ["rust-dap/bitbang", "rust-dap/unproven"]
+pio_set_clock = []
 
 [dependencies]
 rust-dap = { path = "../rust-dap" }

--- a/rust-dap-rp2040/Cargo.toml
+++ b/rust-dap-rp2040/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 
 [features]
 bitbang = ["rust-dap/bitbang", "rust-dap/unproven"]
-pio_set_clock = []
+pio_set_clock = []  # Enable swj_clock implementation for PIO and set appropriate SWCLK frequency. Otherwise, SWCLK is fixed to 15.625[MHz]
 
 [dependencies]
 rust-dap = { path = "../rust-dap" }

--- a/rust-dap-rp2040/Cargo.toml
+++ b/rust-dap-rp2040/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 
 [features]
 bitbang = ["rust-dap/bitbang", "rust-dap/unproven"]
-pio_set_clock = []  # Enable swj_clock implementation for PIO and set appropriate SWCLK frequency. Otherwise, SWCLK is fixed to 15.625[MHz]
+set_clock = []  # Enable swj_clock implementation for bitbang and PIO and set appropriate SWCLK frequency. Otherwise, SWCLK is fixed to 15.625[MHz]
 
 [dependencies]
 rust-dap = { path = "../rust-dap" }

--- a/rust-dap-rp2040/src/pio.rs
+++ b/rust-dap-rp2040/src/pio.rs
@@ -256,7 +256,7 @@ impl<C, D> SwdIoSet<C, D> {
         self.to_swdio_in();
         self.set_clk_pindir(false);
         // Reset clock
-        #[cfg(feature="pio_set_clock")]
+        #[cfg(feature = "pio_set_clock")]
         self.set_clock(DEFAULT_SWJ_CLOCK_HZ);
     }
 }
@@ -482,10 +482,13 @@ impl<C, D> CmsisDapCommandInner for SwdIoSet<C, D> {
         SwdIo::swj_sequence(self, &config.swdio, count, data);
     }
 
-    fn swj_clock(&mut self, config: &mut CmsisDapConfig, frequency_hz: u32) -> core::result::Result<(), DapError> {
+    fn swj_clock(
+        &mut self,
+        config: &mut CmsisDapConfig,
+        frequency_hz: u32,
+    ) -> core::result::Result<(), DapError> {
         SwdIo::swj_clock(self, &mut config.swdio, frequency_hz)
     }
-    
 
     fn swd_sequence(
         &mut self,

--- a/rust-dap-rp2040/src/pio.rs
+++ b/rust-dap-rp2040/src/pio.rs
@@ -256,7 +256,8 @@ impl<C, D> SwdIoSet<C, D> {
         self.to_swdio_in();
         self.set_clk_pindir(false);
         // Reset clock
-        //self.set_clock(DEFAULT_SWJ_CLOCK_HZ);
+        #[cfg(feature="pio_set_clock")]
+        self.set_clock(DEFAULT_SWJ_CLOCK_HZ);
     }
 }
 
@@ -484,6 +485,7 @@ impl<C, D> CmsisDapCommandInner for SwdIoSet<C, D> {
     fn swj_clock(&mut self, config: &mut CmsisDapConfig, frequency_hz: u32) -> core::result::Result<(), DapError> {
         SwdIo::swj_clock(self, &mut config.swdio, frequency_hz)
     }
+    
 
     fn swd_sequence(
         &mut self,

--- a/rust-dap-rp2040/src/util.rs
+++ b/rust-dap-rp2040/src/util.rs
@@ -63,7 +63,22 @@ pub type SwdIoSet<C, D> = PioSwdIoSet<pio0::Pin<C>, pio0::Pin<D>>;
 #[cfg(feature = "bitbang")]
 pub struct CycleDelay {}
 #[cfg(feature = "bitbang")]
+impl CycleDelay {
+    const CPU_FREQUENCY_HZ: u32 = 120000000;            // Default CPU Frequency.
+    const AVERAGE_OPERATION_OVERHEAD_CYCLES: u32 = 60;  // Average SWD/JTAG operation overhead in cycles.
+}
+#[cfg(feature = "bitbang")]
 impl DelayFunc for CycleDelay {
+    #[cfg(feature = "set_clock")]
+    fn calculate_half_clock_cycles(frequency_hz: u32) -> Option<u32> {
+        let cycles = (Self::CPU_FREQUENCY_HZ / 2) / frequency_hz;
+        if cycles < Self::AVERAGE_OPERATION_OVERHEAD_CYCLES {
+            Some(0)
+        } else {
+            Some(cycles - Self::AVERAGE_OPERATION_OVERHEAD_CYCLES)
+        }
+    }
+
     fn cycle_delay(&self, cycles: u32) {
         cortex_m::asm::delay(cycles);
     }

--- a/rust-dap-rp2040/src/util.rs
+++ b/rust-dap-rp2040/src/util.rs
@@ -64,8 +64,8 @@ pub type SwdIoSet<C, D> = PioSwdIoSet<pio0::Pin<C>, pio0::Pin<D>>;
 pub struct CycleDelay {}
 #[cfg(feature = "bitbang")]
 impl CycleDelay {
-    const CPU_FREQUENCY_HZ: u32 = 120000000;            // Default CPU Frequency.
-    const AVERAGE_OPERATION_OVERHEAD_CYCLES: u32 = 60;  // Average SWD/JTAG operation overhead in cycles.
+    const CPU_FREQUENCY_HZ: u32 = 120000000; // Default CPU Frequency.
+    const AVERAGE_OPERATION_OVERHEAD_CYCLES: u32 = 60; // Average SWD/JTAG operation overhead in cycles.
 }
 #[cfg(feature = "bitbang")]
 impl DelayFunc for CycleDelay {

--- a/rust-dap/src/bitbang.rs
+++ b/rust-dap/src/bitbang.rs
@@ -37,6 +37,7 @@ bitflags! {
 }
 
 pub trait DelayFunc {
+    fn calculate_half_clock_cycles(_frequency_hz: u32) -> Option<u32> { None }
     fn cycle_delay(&self, cycles: u32);
 }
 
@@ -146,6 +147,10 @@ where
     SwdIoOutputPin: OutputPin + IoPin<SwdIoInputPin, SwdIoOutputPin>,
     DelayFn: DelayFunc,
 {
+    fn calculate_half_clock_cycles(frequency_hz: u32) -> Option<u32> {
+        DelayFn::calculate_half_clock_cycles(frequency_hz)
+    }
+
     fn to_swclk_in(&mut self) {
         let mut pin = None;
         core::mem::swap(&mut pin, &mut self.swclk_out);
@@ -230,6 +235,8 @@ where
 }
 
 pub trait BitBangSwdIo {
+    fn calculate_half_clock_cycles(_frequency_hz: u32) -> Option<u32> { None }
+
     fn to_swclk_in(&mut self);
     fn to_swclk_out(&mut self, output: bool);
     fn to_swdio_in(&mut self);
@@ -241,11 +248,8 @@ pub trait BitBangSwdIo {
 }
 
 pub trait PrimitiveSwdIo {
-    /// Number of cycles to wait 1[s].
-    /// This constant is used to calculate wait cycles when swj_clock command is 
-    /// executed. 
-    /// If this constant is None, nothing is performed when swj_clock command is executed.
-    const CYCLES_PER_SECOND: Option<u32> = None;
+    /// Calculates number of cycles to delay to generate the target clock frequency.
+    fn calculate_half_clock_cycles(frequency_hz: u32) -> Option<u32> { None }
 
     fn connect(&mut self);
     fn disconnect(&mut self);
@@ -262,6 +266,8 @@ pub trait PrimitiveSwdIo {
 }
 
 impl<Io: BitBangSwdIo> PrimitiveSwdIo for Io {
+    fn calculate_half_clock_cycles(frequency_hz: u32) -> Option<u32> { Io::calculate_half_clock_cycles(frequency_hz) }
+
     fn connect(&mut self) {
         self.to_swclk_out(false);
         self.to_swdio_out(false);
@@ -325,8 +331,8 @@ impl<Io: PrimitiveSwdIo> SwdIo for Io {
         PrimitiveSwdIo::disconnect(self)
     }
     fn swj_clock(&mut self, config: &mut SwdIoConfig, frequency_hz: u32) -> core::result::Result<(), DapError> {
-        match Self::CYCLES_PER_SECOND {
-            Some(cycles_per_second) => config.clock_wait_cycles = if frequency_hz == 0 { 0 } else { cycles_per_second / frequency_hz },   // Update clock_wait_cycles.
+        match Self::calculate_half_clock_cycles(frequency_hz) {
+            Some(cycles) => config.clock_wait_cycles = cycles,   // Update clock_wait_cycles.
             _ => {},
         }
         Ok(())
@@ -806,6 +812,10 @@ where
     SrstOutputPin: OutputPin + IoPin<SrstInputPin, SrstOutputPin>,
     DelayFn: DelayFunc,
 {
+    fn calculate_half_clock_cycles(frequency_hz: u32) -> Option<u32> {
+        DelayFn::calculate_half_clock_cycles(frequency_hz)
+    }
+
     // TCK
     fn to_tck_in(&mut self) {
         turn_to_in(&mut self.tck_in, &mut self.tck_out);
@@ -891,6 +901,8 @@ where
 }
 
 pub trait BitBangJtagIo {
+    fn calculate_half_clock_cycles(_frequency_hz: u32) -> Option<u32> { None }
+
     // TCK
     fn to_tck_in(&mut self);
     fn to_tck_out(&mut self, output: bool);
@@ -926,6 +938,8 @@ pub trait BitBangJtagIo {
 }
 
 pub trait PrimitiveJtagIo {
+    fn calculate_half_clock_cycles(_frequency_hz: u32) -> Option<u32> { None }
+    
     fn connect(&mut self, config: &JtagIoConfig);
     fn disconnect(&mut self, config: &JtagIoConfig);
     fn write_bit(&mut self, config: &JtagIoConfig, tms: bool, tdi: bool);
@@ -933,6 +947,8 @@ pub trait PrimitiveJtagIo {
 }
 
 impl<Io: BitBangJtagIo> PrimitiveJtagIo for Io {
+    fn calculate_half_clock_cycles(frequency_hz: u32) -> Option<u32> { Io::calculate_half_clock_cycles(frequency_hz) }
+    
     fn connect(&mut self, config: &JtagIoConfig) {
         // initial value
         self.to_tck_out(false);
@@ -995,6 +1011,15 @@ impl<Io: PrimitiveJtagIo> JtagIo for Io {
     fn disconnect(&mut self, config: &JtagIoConfig) {
         PrimitiveJtagIo::disconnect(self, config)
     }
+
+    fn swj_clock(&mut self, config: &mut JtagIoConfig, frequency_hz: u32) -> core::result::Result<(), DapError> {
+        match Self::calculate_half_clock_cycles(frequency_hz) {
+            Some(cycles) => config.clock_wait_cycles = cycles,
+            _ => {},
+        }
+        Ok(())
+    }
+
     fn swj_sequence(&mut self, config: &JtagIoConfig, count: usize, data: &[u8]) {
         // https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__SWJ__Sequence.html
         let mut index = 0;
@@ -1297,8 +1322,7 @@ where
     }
 
     fn swj_clock(&mut self, config: &mut CmsisDapConfig, frequency_hz: u32) -> core::result::Result<(), DapError> {
-        // TODO: Implement SWJ_CLOCK for JTAG.
-        Ok(())
+        JtagIo::swj_clock(self, &mut config.jtag, frequency_hz)
     }
 
     fn swd_sequence(

--- a/rust-dap/src/bitbang.rs
+++ b/rust-dap/src/bitbang.rs
@@ -37,7 +37,9 @@ bitflags! {
 }
 
 pub trait DelayFunc {
-    fn calculate_half_clock_cycles(_frequency_hz: u32) -> Option<u32> { None }
+    fn calculate_half_clock_cycles(_frequency_hz: u32) -> Option<u32> {
+        None
+    }
     fn cycle_delay(&self, cycles: u32);
 }
 
@@ -235,7 +237,9 @@ where
 }
 
 pub trait BitBangSwdIo {
-    fn calculate_half_clock_cycles(_frequency_hz: u32) -> Option<u32> { None }
+    fn calculate_half_clock_cycles(_frequency_hz: u32) -> Option<u32> {
+        None
+    }
 
     fn to_swclk_in(&mut self);
     fn to_swclk_out(&mut self, output: bool);
@@ -249,7 +253,9 @@ pub trait BitBangSwdIo {
 
 pub trait PrimitiveSwdIo {
     /// Calculates number of cycles to delay to generate the target clock frequency.
-    fn calculate_half_clock_cycles(frequency_hz: u32) -> Option<u32> { None }
+    fn calculate_half_clock_cycles(frequency_hz: u32) -> Option<u32> {
+        None
+    }
 
     fn connect(&mut self);
     fn disconnect(&mut self);
@@ -266,7 +272,9 @@ pub trait PrimitiveSwdIo {
 }
 
 impl<Io: BitBangSwdIo> PrimitiveSwdIo for Io {
-    fn calculate_half_clock_cycles(frequency_hz: u32) -> Option<u32> { Io::calculate_half_clock_cycles(frequency_hz) }
+    fn calculate_half_clock_cycles(frequency_hz: u32) -> Option<u32> {
+        Io::calculate_half_clock_cycles(frequency_hz)
+    }
 
     fn connect(&mut self) {
         self.to_swclk_out(false);
@@ -330,10 +338,14 @@ impl<Io: PrimitiveSwdIo> SwdIo for Io {
     fn disconnect(&mut self) {
         PrimitiveSwdIo::disconnect(self)
     }
-    fn swj_clock(&mut self, config: &mut SwdIoConfig, frequency_hz: u32) -> core::result::Result<(), DapError> {
+    fn swj_clock(
+        &mut self,
+        config: &mut SwdIoConfig,
+        frequency_hz: u32,
+    ) -> core::result::Result<(), DapError> {
         match Self::calculate_half_clock_cycles(frequency_hz) {
-            Some(cycles) => config.clock_wait_cycles = cycles,   // Update clock_wait_cycles.
-            _ => {},
+            Some(cycles) => config.clock_wait_cycles = cycles, // Update clock_wait_cycles.
+            _ => {}
         }
         Ok(())
     }
@@ -901,7 +913,9 @@ where
 }
 
 pub trait BitBangJtagIo {
-    fn calculate_half_clock_cycles(_frequency_hz: u32) -> Option<u32> { None }
+    fn calculate_half_clock_cycles(_frequency_hz: u32) -> Option<u32> {
+        None
+    }
 
     // TCK
     fn to_tck_in(&mut self);
@@ -938,8 +952,10 @@ pub trait BitBangJtagIo {
 }
 
 pub trait PrimitiveJtagIo {
-    fn calculate_half_clock_cycles(_frequency_hz: u32) -> Option<u32> { None }
-    
+    fn calculate_half_clock_cycles(_frequency_hz: u32) -> Option<u32> {
+        None
+    }
+
     fn connect(&mut self, config: &JtagIoConfig);
     fn disconnect(&mut self, config: &JtagIoConfig);
     fn write_bit(&mut self, config: &JtagIoConfig, tms: bool, tdi: bool);
@@ -947,8 +963,10 @@ pub trait PrimitiveJtagIo {
 }
 
 impl<Io: BitBangJtagIo> PrimitiveJtagIo for Io {
-    fn calculate_half_clock_cycles(frequency_hz: u32) -> Option<u32> { Io::calculate_half_clock_cycles(frequency_hz) }
-    
+    fn calculate_half_clock_cycles(frequency_hz: u32) -> Option<u32> {
+        Io::calculate_half_clock_cycles(frequency_hz)
+    }
+
     fn connect(&mut self, config: &JtagIoConfig) {
         // initial value
         self.to_tck_out(false);
@@ -1012,10 +1030,14 @@ impl<Io: PrimitiveJtagIo> JtagIo for Io {
         PrimitiveJtagIo::disconnect(self, config)
     }
 
-    fn swj_clock(&mut self, config: &mut JtagIoConfig, frequency_hz: u32) -> core::result::Result<(), DapError> {
+    fn swj_clock(
+        &mut self,
+        config: &mut JtagIoConfig,
+        frequency_hz: u32,
+    ) -> core::result::Result<(), DapError> {
         match Self::calculate_half_clock_cycles(frequency_hz) {
             Some(cycles) => config.clock_wait_cycles = cycles,
-            _ => {},
+            _ => {}
         }
         Ok(())
     }
@@ -1321,7 +1343,11 @@ where
         JtagIo::swj_sequence(self, &config.jtag, count, data);
     }
 
-    fn swj_clock(&mut self, config: &mut CmsisDapConfig, frequency_hz: u32) -> core::result::Result<(), DapError> {
+    fn swj_clock(
+        &mut self,
+        config: &mut CmsisDapConfig,
+        frequency_hz: u32,
+    ) -> core::result::Result<(), DapError> {
         JtagIo::swj_clock(self, &mut config.jtag, frequency_hz)
     }
 

--- a/rust-dap/src/cmsis_dap.rs
+++ b/rust-dap/src/cmsis_dap.rs
@@ -119,7 +119,11 @@ pub struct JtagIoConfig {
 pub trait SwdIo {
     fn connect(&mut self);
     fn disconnect(&mut self);
-    fn swj_clock(&mut self, config: &mut SwdIoConfig, frequency_hz: u32) -> core::result::Result<(), DapError>;
+    fn swj_clock(
+        &mut self,
+        config: &mut SwdIoConfig,
+        frequency_hz: u32,
+    ) -> core::result::Result<(), DapError>;
     fn swj_sequence(&mut self, config: &SwdIoConfig, count: usize, data: &[u8]);
     fn swd_read_sequence(&mut self, config: &SwdIoConfig, count: usize, data: &mut [u8]);
     fn swd_write_sequence(&mut self, config: &SwdIoConfig, count: usize, data: &[u8]);
@@ -138,7 +142,11 @@ pub trait SwjIo {}
 pub trait JtagIo {
     fn connect(&mut self, config: &JtagIoConfig);
     fn disconnect(&mut self, config: &JtagIoConfig);
-    fn swj_clock(&mut self, config: &mut JtagIoConfig, frequency_hz: u32) -> core::result::Result<(), DapError>;
+    fn swj_clock(
+        &mut self,
+        config: &mut JtagIoConfig,
+        frequency_hz: u32,
+    ) -> core::result::Result<(), DapError>;
     fn swj_sequence(&mut self, config: &JtagIoConfig, count: usize, data: &[u8]);
     fn jtag_read_sequence(
         &mut self,
@@ -1139,7 +1147,9 @@ where
                     DapCommandId::Delay => self.io.delay(),
                     DapCommandId::ResetTarget => self.io.reset_target(),
                     DapCommandId::SWJPins => self.io.swj_pins(&self.config, request, response_body),
-                    DapCommandId::SWJClock => self.io.swj_clock(&mut self.config, request, response_body),
+                    DapCommandId::SWJClock => {
+                        self.io.swj_clock(&mut self.config, request, response_body)
+                    }
                     DapCommandId::SWJSequence => {
                         self.io.swj_sequence(&self.config, request, response_body)
                     }
@@ -1287,7 +1297,11 @@ mod test {
             todo!()
         }
 
-        fn swj_clock(&mut self, _config: &mut SwdIoConfig, _frequency_hz: u32) -> core::result::Result<(), DapError> {
+        fn swj_clock(
+            &mut self,
+            _config: &mut SwdIoConfig,
+            _frequency_hz: u32,
+        ) -> core::result::Result<(), DapError> {
             todo!()
         }
 

--- a/rust-dap/src/cmsis_dap.rs
+++ b/rust-dap/src/cmsis_dap.rs
@@ -138,6 +138,7 @@ pub trait SwjIo {}
 pub trait JtagIo {
     fn connect(&mut self, config: &JtagIoConfig);
     fn disconnect(&mut self, config: &JtagIoConfig);
+    fn swj_clock(&mut self, config: &mut JtagIoConfig, frequency_hz: u32) -> core::result::Result<(), DapError>;
     fn swj_sequence(&mut self, config: &JtagIoConfig, count: usize, data: &[u8]);
     fn jtag_read_sequence(
         &mut self,


### PR DESCRIPTION
## 対象issue

https://github.com/ciniml/rust-dap/issues/31

## 実装内容

`features=set_clock` を有効にしてビルドすることにより、`SWD` `JTAG` / `bitbang` `PIO` のすべてでそれっぽい周波数になるようにクロックやディレイ等を調整するようにした

## 制限事項

PIOはそこそこ指定した周波数に近いクロックを生成するが、bitbangはかなり適当 (処理間のディレイを調整してるだけなのでしかたない)