### PR TITLE
Add swd to default feature of rpi_pico

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,6 +36,6 @@ jobs:
         run: |
           cargo clippy --features swd
           cargo clippy --features swd,bitbang
-          cargo clippy --features jtag
+          cargo clippy --no-default-features --features jtag
         working-directory: ${{ matrix.projects }}
         if: ${{ matrix.projects  == 'boards/rpi_pico' }}

--- a/boards/rpi_pico/Cargo.toml
+++ b/boards/rpi_pico/Cargo.toml
@@ -14,6 +14,7 @@ opt-level = 3
 lto = true
 
 [features]
+default = ["swd"]
 bitbang = ["rust-dap/bitbang", "rust-dap-rp2040/bitbang"]
 set_clock = ["rust-dap-rp2040/set_clock"]   # Enable swj_clock implementation for PIO and set appropriate SWCLK frequency. Otherwise, SWCLK is fixed to 15.625[MHz]
 jtag = ["bitbang"]

--- a/boards/rpi_pico/README.md
+++ b/boards/rpi_pico/README.md
@@ -51,10 +51,6 @@ cargo build --release --no-default-features --features jtag
 cargo build --release --no-default-features --features jtag,set_clock
 ```
 
-
-
-
-
 ## 使い方
 
 ### pyOCDを使う場合

--- a/boards/rpi_pico/README.md
+++ b/boards/rpi_pico/README.md
@@ -4,12 +4,56 @@
 
 ![ピン配置](./rust-dap-pico.svg)
 
-| ピン番号 | ピン名 | SWDピン接続先 |
-|:--------|:-------|:-------------|
-| 3       | GND    | GND          |
-| 4       | GPIO2  | SWCLK        |
-| 5       | GPIO3  | SWDIO        |
-| 6       | GPIO4  | RESET        |
+| ピン番号 | ピン名 | SWDピン接続先 | JTAGピン接続先 |
+|:--------|:-------|:-------------|:--------------|
+| 3       | GND    | GND          | GND           |
+| 4       | GPIO2  | SWCLK        | TCK           |
+| 5       | GPIO3  | SWDIO        | TMS           |
+| 6       | GPIO4  | RESET        | nSRST         |
+| 7       | GPIO5  |              | TDO           |
+| 9       | GPIO6  |              | TDI           |
+| 10      | GPIO7  |              | nTRST         |
+
+## ビルド
+
+### SWD用
+
+デフォルトのfeatureではPIOを使ったSWD用のrust-dapをビルドします。
+
+```
+cargo build --release
+```
+
+feature `bitbang` を有効にすると、PIOを使ったSWD通信処理ではなく、GPIOをCPUで制御してSWD通信処理を行います。
+
+```
+cargo build --release --features bitbang
+```
+
+ホストからのクロックレートの設定を有効にするには feature `set_clock` を有効にします。 PIO向けの場合はかなり正確にクロックレートを設定できますが、bitbangの場合はそれなりです。
+
+```
+cargo build --release --features set_clock # PIO
+cargo build --release --features set_clock,bitbang # bitbang
+```
+
+### JTAG用
+
+JTAG用のファームウェアをビルドするには、 `--no-default-featrues` をつけて デフォルトで有効であるSWD機能のfeatureを無効化したうえで、 `jtag` featureを有効にします。
+
+```
+cargo build --release --no-default-features --features jtag
+```
+
+ホストからのクロックレートの設定を有効にするには feature `set_clock` を有効にします。
+
+```
+cargo build --release --no-default-features --features jtag,set_clock
+```
+
+
+
+
 
 ## 使い方
 

--- a/rust-dap-rp2040/Cargo.lock
+++ b/rust-dap-rp2040/Cargo.lock
@@ -138,6 +138,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc-any"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774646b687f63643eb0f4bf13dc263cb581c8c9e57973b6ddf78bda3994d88df"
+dependencies = [
+ "debug-helper",
+]
+
+[[package]]
 name = "critical-section"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +157,12 @@ dependencies = [
  "cortex-m",
  "riscv",
 ]
+
+[[package]]
+name = "debug-helper"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f578e8e2c440e7297e008bb5486a3a8a194775224bbc23729b0dbdfaeebf162e"
 
 [[package]]
 name = "either"
@@ -450,6 +465,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rp2040-boot2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b480fe63133f0d639f82ce5a027fee7cac7ac92f67ef1896ee036a6f9737128"
+dependencies = [
+ "crc-any",
+]
+
+[[package]]
 name = "rp2040-hal"
 version = "0.4.0"
 source = "git+https://github.com/rp-rs/rp-hal.git?rev=8d18abdfc7c0129debba85457d32d32175bf36bd#8d18abdfc7c0129debba85457d32d32175bf36bd"
@@ -528,6 +552,7 @@ dependencies = [
  "nb 0.1.3",
  "panic-halt",
  "pio",
+ "rp2040-boot2",
  "rp2040-hal",
  "rust-dap",
  "usb-device",


### PR DESCRIPTION
#41 の対応。

boards/rpi_pico で `cargo build` を実行したときにエラーとなるのではなく、デフォルトでSWD向けの構成でビルドするようにする。