### PR TITLE
Fix regression of swd_sequence of bitbang and PIO implementation.

### DIFF
--- a/rust-dap-rp2040/src/pio.rs
+++ b/rust-dap-rp2040/src/pio.rs
@@ -527,6 +527,7 @@ impl<C, D> CmsisDapCommandInner for SwdIoSet<C, D> {
                     clock_count,
                     &mut response[response_index..],
                 );
+                response_index += bytes_count;
             } else {
                 SwdIo::enable_output(self);
                 SwdIo::swd_write_sequence(
@@ -535,17 +536,11 @@ impl<C, D> CmsisDapCommandInner for SwdIoSet<C, D> {
                     clock_count,
                     &request[request_index..],
                 );
+                request_index += bytes_count;
             }
 
             if sequence_count == 0 {
                 SwdIo::enable_output(self)
-            }
-
-            if do_input {
-                request_index += 1;
-                response_index += bytes_count;
-            } else {
-                request_index = 1 + bytes_count;
             }
         }
         response[0] = DAP_OK;

--- a/rust-dap/src/bitbang.rs
+++ b/rust-dap/src/bitbang.rs
@@ -576,6 +576,7 @@ where
                     clock_count,
                     &mut response[response_index..],
                 );
+                response_index += bytes_count;
             } else {
                 SwdIo::enable_output(self);
                 SwdIo::swd_write_sequence(
@@ -584,17 +585,11 @@ where
                     clock_count,
                     &request[request_index..],
                 );
+                request_index += bytes_count;
             }
 
             if sequence_count == 0 {
                 SwdIo::enable_output(self)
-            }
-
-            if do_input {
-                request_index += 1;
-                response_index += bytes_count;
-            } else {
-                request_index = 1 + bytes_count;
             }
         }
         response[0] = DAP_OK;


### PR DESCRIPTION
`swd_sequence` の修正がJTAG機能マージ時に漏れていたのを修正

fix #44 