### PR TITLE
Initial support the nRESET pin for bitbang

### DIFF
--- a/boards/rpi_pico/src/main.rs
+++ b/boards/rpi_pico/src/main.rs
@@ -39,7 +39,9 @@ mod app {
     use rust_dap_rp2040::util::{
         initialize_usb, read_usb_serial_byte_cs, write_usb_serial_byte_cs, UartConfigAndClock,
     };
-    #[cfg(feature = "swd")]
+    #[cfg(all(feature = "swd", feature = "bitbang"))]
+    type SwdIoSet = rust_dap_rp2040::util::SwdIoSet<GpioSwClk, GpioSwdIo, GpioReset>;
+    #[cfg(all(feature = "swd", not(feature = "bitbang")))]
     type SwdIoSet = rust_dap_rp2040::util::SwdIoSet<GpioSwClk, GpioSwdIo>;
     #[cfg(feature = "jtag")]
     type JtagIoSet = rust_dap_rp2040::util::JtagIoSet<
@@ -68,6 +70,8 @@ mod app {
     type GpioSwClk = hal::gpio::bank0::Gpio2;
     #[cfg(feature = "swd")]
     type GpioSwdIo = hal::gpio::bank0::Gpio3;
+    #[cfg(feature = "swd")]
+    type GpioReset = hal::gpio::bank0::Gpio4;
     // jtag
     #[cfg(feature = "jtag")]
     type JtagTckPin = hal::gpio::bank0::Gpio2;
@@ -175,26 +179,24 @@ mod app {
         ));
         c.local.USB_ALLOCATOR.replace(usb_allocator);
         let usb_allocator = c.local.USB_ALLOCATOR.as_ref().unwrap();
-
-        // Initialize MCU reset pin.
-        // Currently MCU reset pin is not used,
-        // so all we have to do is just initialize the pin in case the pin is connected to the target RESET.
         #[cfg(feature = "swd")]
-        {
+        let (usb_serial, usb_dap, usb_bus) = {
+            // Initialize MCU reset pin.
             let mut n_reset_pin = pins.gpio4.into_push_pull_output();
             // RESET pin of Cortex Debug 10-pin connector is negarive logic
             // https://developer.arm.com/documentation/101453/0100/CoreSight-Technology/Connectors
             n_reset_pin.set_high().ok();
-        }
-        #[cfg(feature = "swd")]
-        let (usb_serial, usb_dap, usb_bus) = {
+
             let swdio;
             #[cfg(feature = "bitbang")]
             {
-                use rust_dap_rp2040::{swdio_pin::PicoSwdInputPin, util::CycleDelay};
+                use rust_dap_rp2040::{
+                    swdio_pin::PicoSwdInputPin, swdio_pin::PicoSwdOutputPin, util::CycleDelay,
+                };
                 let swclk_pin = PicoSwdInputPin::new(pins.gpio2.into_floating_input());
                 let swdio_pin = PicoSwdInputPin::new(pins.gpio3.into_floating_input());
-                swdio = SwdIoSet::new(swclk_pin, swdio_pin, CycleDelay {});
+                let reset_pin = PicoSwdOutputPin::new(n_reset_pin);
+                swdio = SwdIoSet::new(swclk_pin, swdio_pin, reset_pin, CycleDelay {});
             }
             #[cfg(not(feature = "bitbang"))]
             {

--- a/boards/xiao_m0/src/main.rs
+++ b/boards/xiao_m0/src/main.rs
@@ -97,7 +97,7 @@ fn main() -> ! {
     };
 
     let mut n_reset_pin = pins.a0.into_push_pull_output();
-    // RESET pin of Cortex Debug 10-pin connector is negarive logic
+    // RESET pin of Cortex Debug 10-pin connector is negative logic
     // https://developer.arm.com/documentation/101453/0100/CoreSight-Technology/Connectors
     n_reset_pin.set_high().ok();
 

--- a/boards/xiao_m0/src/main.rs
+++ b/boards/xiao_m0/src/main.rs
@@ -17,7 +17,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::v2::ToggleableOutputPin;
+use embedded_hal::digital::v2::{OutputPin, ToggleableOutputPin};
 use panic_halt as _;
 use rust_dap::bitbang::{DelayFunc, SwdIoSet};
 use rust_dap::{
@@ -43,16 +43,26 @@ mod swdio_pin;
 use swdio_pin::*;
 
 // Import pin types.
-use hal::gpio::v2::{PA05, PA07, PA18};
+use hal::gpio::v2::{PA02, PA05, PA07, PA18};
 
-type SwdIoPin = PA05;
-type SwClkPin = PA07;
+type SwdIoPin = PA05; // D9
+type SwClkPin = PA07; // D8
+type ResetPin = PA02; // D0
 type SwdIoInputPin = XiaoSwdInputPin<SwdIoPin>;
 type SwdIoOutputPin = XiaoSwdOutputPin<SwdIoPin>;
 type SwClkInputPin = XiaoSwdInputPin<SwClkPin>;
 type SwClkOutputPin = XiaoSwdOutputPin<SwClkPin>;
-type MySwdIoSet =
-    SwdIoSet<SwClkInputPin, SwClkOutputPin, SwdIoInputPin, SwdIoOutputPin, CycleDelay>;
+type ResetInputPin = XiaoSwdInputPin<ResetPin>;
+type ResetOutputPin = XiaoSwdOutputPin<ResetPin>;
+type MySwdIoSet = SwdIoSet<
+    SwClkInputPin,
+    SwClkOutputPin,
+    SwdIoInputPin,
+    SwdIoOutputPin,
+    ResetInputPin,
+    ResetOutputPin,
+    CycleDelay,
+>;
 
 struct CycleDelay {}
 impl DelayFunc for CycleDelay {
@@ -86,9 +96,15 @@ fn main() -> ! {
         USB_ALLOCATOR.as_ref().unwrap()
     };
 
+    let mut n_reset_pin = pins.a0.into_push_pull_output();
+    // RESET pin of Cortex Debug 10-pin connector is negarive logic
+    // https://developer.arm.com/documentation/101453/0100/CoreSight-Technology/Connectors
+    n_reset_pin.set_high().ok();
+
     let swdio = MySwdIoSet::new(
         XiaoSwdInputPin::new(pins.a8.into_floating_input()),
         XiaoSwdInputPin::new(pins.a9.into_floating_input()),
+        XiaoSwdOutputPin::new(n_reset_pin),
         CycleDelay {},
     );
 

--- a/rust-dap-rp2040/src/util.rs
+++ b/rust-dap-rp2040/src/util.rs
@@ -30,11 +30,13 @@ use crate::swdio_pin::{PicoSwdInputPin, PicoSwdOutputPin};
 #[cfg(feature = "bitbang")]
 use rust_dap::bitbang::{DelayFunc, JtagIoSet as BitbangJtagIoSet, SwdIoSet as BitbangSwdIoSet};
 #[cfg(feature = "bitbang")]
-pub type SwdIoSet<C, D> = BitbangSwdIoSet<
+pub type SwdIoSet<C, D, E> = BitbangSwdIoSet<
     PicoSwdInputPin<C>,
     PicoSwdOutputPin<C>,
     PicoSwdInputPin<D>,
     PicoSwdOutputPin<D>,
+    PicoSwdInputPin<E>,
+    PicoSwdOutputPin<E>,
     CycleDelay,
 >;
 #[cfg(feature = "bitbang")]

--- a/rust-dap/src/bitbang.rs
+++ b/rust-dap/src/bitbang.rs
@@ -27,12 +27,14 @@ use embedded_hal::digital::v2::{InputPin, IoPin, OutputPin, PinState};
 // https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__SWJ__Pins.html
 bitflags! {
     struct SwjPins: u8 {
-        const TCK_SWDCLK = 1;
-        const TMS_SWDIO = 1 << 1;
-        const TDI = 1 << 2;
-        const TDO = 1 << 3;
-        const N_TRST = 1 << 5;
-        const N_RESET = 1 << 7;
+        const TCK_SWDCLK = 1 << 0;
+        const TMS_SWDIO  = 1 << 1;
+        const TDI        = 1 << 2;
+        const TDO        = 1 << 3;
+        const UNKNOWN4   = 1 << 4;
+        const N_TRST     = 1 << 5;
+        const UNKNOWN6   = 1 << 6;
+        const N_RESET    = 1 << 7;
     }
 }
 
@@ -105,48 +107,102 @@ fn get_input<I: InputPin + IoPin<I, O>, O: OutputPin + IoPin<I, O>>(
 ///////////////////
 /////// SWD ///////
 ///////////////////
-pub struct SwdIoSet<SwClkInputPin, SwClkOutputPin, SwdIoInputPin, SwdIoOutputPin, DelayFn>
-where
+pub struct SwdIoSet<
+    SwClkInputPin,
+    SwClkOutputPin,
+    SwdIoInputPin,
+    SwdIoOutputPin,
+    ResetInputPin,
+    ResetOutputPin,
+    DelayFn,
+> where
     SwClkInputPin: InputPin + IoPin<SwClkInputPin, SwClkOutputPin>,
     SwClkOutputPin: OutputPin + IoPin<SwClkInputPin, SwClkOutputPin>,
     SwdIoInputPin: InputPin + IoPin<SwdIoInputPin, SwdIoOutputPin>,
     SwdIoOutputPin: OutputPin + IoPin<SwdIoInputPin, SwdIoOutputPin>,
+    ResetInputPin: InputPin + IoPin<ResetInputPin, ResetOutputPin>,
+    ResetOutputPin: OutputPin + IoPin<ResetInputPin, ResetOutputPin>,
     DelayFn: DelayFunc,
 {
     swdio_in: Option<SwdIoInputPin>,
     swdio_out: Option<SwdIoOutputPin>,
     swclk_in: Option<SwClkInputPin>,
     swclk_out: Option<SwClkOutputPin>,
+    reset_in: Option<ResetInputPin>,
+    reset_out: Option<ResetOutputPin>,
     cycle_delay: DelayFn,
 }
 
-impl<SwClkInputPin, SwClkOutputPin, SwdIoInputPin, SwdIoOutputPin, DelayFn>
-    SwdIoSet<SwClkInputPin, SwClkOutputPin, SwdIoInputPin, SwdIoOutputPin, DelayFn>
+impl<
+        SwClkInputPin,
+        SwClkOutputPin,
+        SwdIoInputPin,
+        SwdIoOutputPin,
+        ResetInputPin,
+        ResetOutputPin,
+        DelayFn,
+    >
+    SwdIoSet<
+        SwClkInputPin,
+        SwClkOutputPin,
+        SwdIoInputPin,
+        SwdIoOutputPin,
+        ResetInputPin,
+        ResetOutputPin,
+        DelayFn,
+    >
 where
     SwClkInputPin: InputPin + IoPin<SwClkInputPin, SwClkOutputPin>,
     SwClkOutputPin: OutputPin + IoPin<SwClkInputPin, SwClkOutputPin>,
     SwdIoInputPin: InputPin + IoPin<SwdIoInputPin, SwdIoOutputPin>,
     SwdIoOutputPin: OutputPin + IoPin<SwdIoInputPin, SwdIoOutputPin>,
+    ResetInputPin: InputPin + IoPin<ResetInputPin, ResetOutputPin>,
+    ResetOutputPin: OutputPin + IoPin<ResetInputPin, ResetOutputPin>,
     DelayFn: DelayFunc,
 {
-    pub fn new(swclk: SwClkInputPin, swdio: SwdIoInputPin, cycle_delay: DelayFn) -> Self {
+    pub fn new(
+        swclk: SwClkInputPin,
+        swdio: SwdIoInputPin,
+        reset: ResetOutputPin,
+        cycle_delay: DelayFn,
+    ) -> Self {
         Self {
             swdio_in: Some(swdio),
             swdio_out: None,
             swclk_in: Some(swclk),
             swclk_out: None,
+            reset_in: None,
+            reset_out: Some(reset),
             cycle_delay,
         }
     }
 }
 
-impl<SwClkInputPin, SwClkOutputPin, SwdIoInputPin, SwdIoOutputPin, DelayFn> BitBangSwdIo
-    for SwdIoSet<SwClkInputPin, SwClkOutputPin, SwdIoInputPin, SwdIoOutputPin, DelayFn>
+impl<
+        SwClkInputPin,
+        SwClkOutputPin,
+        SwdIoInputPin,
+        SwdIoOutputPin,
+        ResetInputPin,
+        ResetOutputPin,
+        DelayFn,
+    > BitBangSwdIo
+    for SwdIoSet<
+        SwClkInputPin,
+        SwClkOutputPin,
+        SwdIoInputPin,
+        SwdIoOutputPin,
+        ResetInputPin,
+        ResetOutputPin,
+        DelayFn,
+    >
 where
     SwClkInputPin: InputPin + IoPin<SwClkInputPin, SwClkOutputPin>,
     SwClkOutputPin: OutputPin + IoPin<SwClkInputPin, SwClkOutputPin>,
     SwdIoInputPin: InputPin + IoPin<SwdIoInputPin, SwdIoOutputPin>,
     SwdIoOutputPin: OutputPin + IoPin<SwdIoInputPin, SwdIoOutputPin>,
+    ResetInputPin: InputPin + IoPin<ResetInputPin, ResetOutputPin>,
+    ResetOutputPin: OutputPin + IoPin<ResetInputPin, ResetOutputPin>,
     DelayFn: DelayFunc,
 {
     fn calculate_half_clock_cycles(frequency_hz: u32) -> Option<u32> {
@@ -207,6 +263,33 @@ where
             );
         }
     }
+    fn to_reset_in(&mut self) {
+        let mut pin = None;
+        core::mem::swap(&mut pin, &mut self.reset_out);
+        if let Some(reset_out) = pin {
+            self.reset_in = Some(
+                reset_out
+                    .into_input_pin()
+                    .unwrap_or_else(|_| panic!("Failed to turn RESET pin to input.")),
+            );
+        }
+    }
+    fn to_reset_out(&mut self, output: bool) {
+        let mut pin = None;
+        core::mem::swap(&mut pin, &mut self.reset_in);
+        if let Some(reset_in) = pin {
+            let state = if output {
+                PinState::High
+            } else {
+                PinState::Low
+            };
+            self.reset_out = Some(
+                reset_in
+                    .into_output_pin(state)
+                    .unwrap_or_else(|_| panic!("Failed to turn RESET pin to output.")),
+            );
+        }
+    }
     fn set_swclk_output(&mut self, output: bool) {
         self.swclk_out.as_mut().and_then(|p| {
             if output {
@@ -225,8 +308,29 @@ where
             }
         });
     }
+    fn set_reset_output(&mut self, output: bool) {
+        self.reset_out.as_mut().and_then(|p| {
+            if output {
+                p.set_high().ok()
+            } else {
+                p.set_low().ok()
+            }
+        });
+    }
     fn get_swdio_input(&mut self) -> bool {
         self.swdio_in
+            .as_mut()
+            .map(|p| p.is_high().unwrap_or(false))
+            .unwrap()
+    }
+    fn get_swclk_input(&mut self) -> bool {
+        self.swclk_in
+            .as_mut()
+            .map(|p| p.is_high().unwrap_or(false))
+            .unwrap()
+    }
+    fn get_reset_input(&mut self) -> bool {
+        self.reset_in
             .as_mut()
             .map(|p| p.is_high().unwrap_or(false))
             .unwrap()
@@ -240,14 +344,18 @@ pub trait BitBangSwdIo {
     fn calculate_half_clock_cycles(_frequency_hz: u32) -> Option<u32> {
         None
     }
-
     fn to_swclk_in(&mut self);
     fn to_swclk_out(&mut self, output: bool);
     fn to_swdio_in(&mut self);
     fn to_swdio_out(&mut self, output: bool);
+    fn to_reset_in(&mut self);
+    fn to_reset_out(&mut self, output: bool);
     fn set_swclk_output(&mut self, output: bool);
     fn set_swdio_output(&mut self, output: bool);
+    fn set_reset_output(&mut self, output: bool);
+    fn get_swclk_input(&mut self) -> bool;
     fn get_swdio_input(&mut self) -> bool;
+    fn get_reset_input(&mut self) -> bool;
     fn clock_wait(&self, config: &SwdIoConfig);
 }
 
@@ -522,13 +630,31 @@ impl<Io: PrimitiveSwdIo> SwdIo for Io {
     }
 }
 
-impl<SwClkInputPin, SwClkOutputPin, SwdIoInputPin, SwdIoOutputPin, DelayFn> CmsisDapCommandInner
-    for SwdIoSet<SwClkInputPin, SwClkOutputPin, SwdIoInputPin, SwdIoOutputPin, DelayFn>
+impl<
+        SwClkInputPin,
+        SwClkOutputPin,
+        SwdIoInputPin,
+        SwdIoOutputPin,
+        ResetInputPin,
+        ResetOutputPin,
+        DelayFn,
+    > CmsisDapCommandInner
+    for SwdIoSet<
+        SwClkInputPin,
+        SwClkOutputPin,
+        SwdIoInputPin,
+        SwdIoOutputPin,
+        ResetInputPin,
+        ResetOutputPin,
+        DelayFn,
+    >
 where
     SwClkInputPin: InputPin + IoPin<SwClkInputPin, SwClkOutputPin>,
     SwClkOutputPin: OutputPin + IoPin<SwClkInputPin, SwClkOutputPin>,
     SwdIoInputPin: InputPin + IoPin<SwdIoInputPin, SwdIoOutputPin>,
     SwdIoOutputPin: OutputPin + IoPin<SwdIoInputPin, SwdIoOutputPin>,
+    ResetInputPin: InputPin + IoPin<ResetInputPin, ResetOutputPin>,
+    ResetOutputPin: OutputPin + IoPin<ResetInputPin, ResetOutputPin>,
     DelayFn: DelayFunc,
 {
     fn connect(&mut self, _config: &CmsisDapConfig) {
@@ -620,12 +746,94 @@ where
     fn swj_pins(
         &mut self,
         _config: &CmsisDapConfig,
-        _pin_output: u8,
-        _pin_select: u8,
-        _wait_us: u32,
+        pin_output: u8,
+        pin_select: u8,
+        wait_us: u32,
     ) -> core::result::Result<u8, DapError> {
-        // TODO: write
-        Ok(0)
+        let pin_output = SwjPins::from_bits(pin_output).unwrap();
+        let pin_select = SwjPins::from_bits(pin_select).unwrap();
+
+        let flags = [
+            SwjPins::TCK_SWDCLK,
+            SwjPins::TMS_SWDIO,
+            SwjPins::TDI,
+            SwjPins::TDO,
+            SwjPins::N_TRST,
+            SwjPins::N_RESET,
+        ];
+
+        // output
+        for f in flags {
+            if pin_select.contains(f) {
+                let output = pin_output.contains(f);
+                match f {
+                    SwjPins::TCK_SWDCLK => {
+                        // TODO: inputならoutputにする
+                        // TODO: outputする値を覚えておいて、最後にもとに戻す
+                        self.set_swclk_output(output);
+                    }
+                    SwjPins::TMS_SWDIO => {
+                        self.set_swdio_output(output);
+                    }
+                    SwjPins::N_RESET => {
+                        self.set_reset_output(output);
+                    }
+                    _ => (),
+                }
+            }
+        }
+
+        // FIXIT: get core clock from system
+        // CORE_CLOCK / 1000000 * wait_us
+        const CORE_CLOCK: u64 = 125000000;
+        self.cycle_delay
+            .cycle_delay((CORE_CLOCK * wait_us as u64 / 1000000u64) as u32);
+
+        // backup
+        let swclk_is_output = self.swclk_out.is_some();
+        let swdio_is_output = self.swdio_out.is_some();
+        let n_reset_is_output = self.reset_out.is_some();
+
+        // change io
+        if swclk_is_output {
+            self.to_swclk_in();
+        }
+        if swdio_is_output {
+            self.to_swdio_in();
+        }
+        if n_reset_is_output {
+            self.to_reset_in();
+        }
+
+        // input
+        let mut pin_input = if self.get_swclk_input() {
+            SwjPins::TCK_SWDCLK
+        } else {
+            SwjPins::empty()
+        };
+        pin_input |= if self.get_swdio_input() {
+            SwjPins::TMS_SWDIO
+        } else {
+            SwjPins::empty()
+        };
+        pin_input |= if self.get_reset_input() {
+            SwjPins::N_RESET
+        } else {
+            SwjPins::empty()
+        };
+
+        // restore io
+        if swclk_is_output {
+            self.to_swclk_out(false);
+        }
+        if swdio_is_output {
+            self.to_swdio_out(false);
+        }
+        if n_reset_is_output {
+            self.to_reset_out(true);
+        }
+
+        Ok(pin_input.bits())
     }
 
     fn swj_clock(


### PR DESCRIPTION
# やりたいこと

- SWDでnRESETピンを使ってリセットできるようにしたい

# やったこと

- swj_pins でnRESETを制御できるようにした
    - bitbang時のみサポート

# 動作検証方法

1. nRESET対応したファームをPi Picoに書き込む
2. OpenOCDを立ち上げる
    - `openocd -f interface/cmsis-dap.cfg -c 'transport select swd'`
3. telnetでOpenOCDに繋いで以下を実行
    - `cmsis-dap cmd 0x10 0xff 0xff 0xff 0xff 0x10 0x00` (all Highにする)
    - `cmsis-dap cmd 0x10 0x00 0xff 0xff 0xff 0x10 0x00` (all Lowにする（終了後はHighに戻る))
4. Picoのpin 6の電圧をオシロ等で確認する

# 課題

- 簡単のため、待ち(wait_us)がRasPi Picoでしか動かない実装になっています。なにか良い方法あればアドバイスほしいです。
