### PR TITLE
Initial support the nRESET pin for bitbang and PIO

### DIFF
--- a/boards/rpi_pico/src/main.rs
+++ b/boards/rpi_pico/src/main.rs
@@ -39,7 +39,9 @@ mod app {
     use rust_dap_rp2040::util::{
         initialize_usb, read_usb_serial_byte_cs, write_usb_serial_byte_cs, UartConfigAndClock,
     };
-    #[cfg(feature = "swd")]
+    #[cfg(all(feature = "swd", feature = "bitbang"))]
+    type SwdIoSet = rust_dap_rp2040::util::SwdIoSet<GpioSwClk, GpioSwdIo, GpioReset>;
+    #[cfg(all(feature = "swd", not(feature = "bitbang")))]
     type SwdIoSet = rust_dap_rp2040::util::SwdIoSet<GpioSwClk, GpioSwdIo>;
     #[cfg(feature = "jtag")]
     type JtagIoSet = rust_dap_rp2040::util::JtagIoSet<
@@ -68,6 +70,8 @@ mod app {
     type GpioSwClk = hal::gpio::bank0::Gpio2;
     #[cfg(feature = "swd")]
     type GpioSwdIo = hal::gpio::bank0::Gpio3;
+    #[cfg(feature = "swd")]
+    type GpioReset = hal::gpio::bank0::Gpio4;
     // jtag
     #[cfg(feature = "jtag")]
     type JtagTckPin = hal::gpio::bank0::Gpio2;
@@ -175,26 +179,24 @@ mod app {
         ));
         c.local.USB_ALLOCATOR.replace(usb_allocator);
         let usb_allocator = c.local.USB_ALLOCATOR.as_ref().unwrap();
-
-        // Initialize MCU reset pin.
-        // Currently MCU reset pin is not used,
-        // so all we have to do is just initialize the pin in case the pin is connected to the target RESET.
         #[cfg(feature = "swd")]
-        {
+        let (usb_serial, usb_dap, usb_bus) = {
+            // Initialize MCU reset pin.
             let mut n_reset_pin = pins.gpio4.into_push_pull_output();
             // RESET pin of Cortex Debug 10-pin connector is negarive logic
             // https://developer.arm.com/documentation/101453/0100/CoreSight-Technology/Connectors
             n_reset_pin.set_high().ok();
-        }
-        #[cfg(feature = "swd")]
-        let (usb_serial, usb_dap, usb_bus) = {
+
             let swdio;
             #[cfg(feature = "bitbang")]
             {
-                use rust_dap_rp2040::{swdio_pin::PicoSwdInputPin, util::CycleDelay};
+                use rust_dap_rp2040::{
+                    swdio_pin::PicoSwdInputPin, swdio_pin::PicoSwdOutputPin, util::CycleDelay,
+                };
                 let swclk_pin = PicoSwdInputPin::new(pins.gpio2.into_floating_input());
                 let swdio_pin = PicoSwdInputPin::new(pins.gpio3.into_floating_input());
-                swdio = SwdIoSet::new(swclk_pin, swdio_pin, CycleDelay {});
+                let reset_pin = PicoSwdOutputPin::new(n_reset_pin);
+                swdio = SwdIoSet::new(swclk_pin, swdio_pin, reset_pin, CycleDelay {});
             }
             #[cfg(not(feature = "bitbang"))]
             {

--- a/boards/rpi_pico/src/main.rs
+++ b/boards/rpi_pico/src/main.rs
@@ -42,7 +42,7 @@ mod app {
     #[cfg(all(feature = "swd", feature = "bitbang"))]
     type SwdIoSet = rust_dap_rp2040::util::SwdIoSet<GpioSwClk, GpioSwdIo, GpioReset>;
     #[cfg(all(feature = "swd", not(feature = "bitbang")))]
-    type SwdIoSet = rust_dap_rp2040::util::SwdIoSet<GpioSwClk, GpioSwdIo>;
+    type SwdIoSet = rust_dap_rp2040::util::SwdIoSet<GpioSwClk, GpioSwdIo, GpioReset>;
     #[cfg(feature = "jtag")]
     type JtagIoSet = rust_dap_rp2040::util::JtagIoSet<
         JtagTckPin,
@@ -204,7 +204,16 @@ mod app {
                 let mut swdio_pin = pins.gpio3.into_mode();
                 swclk_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
                 swdio_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
-                swdio = SwdIoSet::new(c.device.PIO0, swclk_pin, swdio_pin, &mut resets);
+                let mut n_reset_pin = n_reset_pin.into_mode();
+                n_reset_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
+
+                swdio = SwdIoSet::new(
+                    c.device.PIO0,
+                    swclk_pin,
+                    swdio_pin,
+                    n_reset_pin,
+                    &mut resets,
+                );
             }
             initialize_usb(
                 swdio,

--- a/boards/rpi_pico/src/main.rs
+++ b/boards/rpi_pico/src/main.rs
@@ -183,7 +183,7 @@ mod app {
         let (usb_serial, usb_dap, usb_bus) = {
             // Initialize MCU reset pin.
             let mut n_reset_pin = pins.gpio4.into_push_pull_output();
-            // RESET pin of Cortex Debug 10-pin connector is negarive logic
+            // RESET pin of Cortex Debug 10-pin connector is negative logic
             // https://developer.arm.com/documentation/101453/0100/CoreSight-Technology/Connectors
             n_reset_pin.set_high().ok();
 

--- a/boards/xiao_m0/src/main.rs
+++ b/boards/xiao_m0/src/main.rs
@@ -97,7 +97,7 @@ fn main() -> ! {
     };
 
     let mut n_reset_pin = pins.a0.into_push_pull_output();
-    // RESET pin of Cortex Debug 10-pin connector is negarive logic
+    // RESET pin of Cortex Debug 10-pin connector is negative logic
     // https://developer.arm.com/documentation/101453/0100/CoreSight-Technology/Connectors
     n_reset_pin.set_high().ok();
 

--- a/boards/xiao_m0/src/main.rs
+++ b/boards/xiao_m0/src/main.rs
@@ -17,7 +17,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::v2::ToggleableOutputPin;
+use embedded_hal::digital::v2::{OutputPin, ToggleableOutputPin};
 use panic_halt as _;
 use rust_dap::bitbang::{DelayFunc, SwdIoSet};
 use rust_dap::{
@@ -43,16 +43,26 @@ mod swdio_pin;
 use swdio_pin::*;
 
 // Import pin types.
-use hal::gpio::v2::{PA05, PA07, PA18};
+use hal::gpio::v2::{PA02, PA05, PA07, PA18};
 
-type SwdIoPin = PA05;
-type SwClkPin = PA07;
+type SwdIoPin = PA05; // D9
+type SwClkPin = PA07; // D8
+type ResetPin = PA02; // D0
 type SwdIoInputPin = XiaoSwdInputPin<SwdIoPin>;
 type SwdIoOutputPin = XiaoSwdOutputPin<SwdIoPin>;
 type SwClkInputPin = XiaoSwdInputPin<SwClkPin>;
 type SwClkOutputPin = XiaoSwdOutputPin<SwClkPin>;
-type MySwdIoSet =
-    SwdIoSet<SwClkInputPin, SwClkOutputPin, SwdIoInputPin, SwdIoOutputPin, CycleDelay>;
+type ResetInputPin = XiaoSwdInputPin<ResetPin>;
+type ResetOutputPin = XiaoSwdOutputPin<ResetPin>;
+type MySwdIoSet = SwdIoSet<
+    SwClkInputPin,
+    SwClkOutputPin,
+    SwdIoInputPin,
+    SwdIoOutputPin,
+    ResetInputPin,
+    ResetOutputPin,
+    CycleDelay,
+>;
 
 struct CycleDelay {}
 impl DelayFunc for CycleDelay {
@@ -86,9 +96,15 @@ fn main() -> ! {
         USB_ALLOCATOR.as_ref().unwrap()
     };
 
+    let mut n_reset_pin = pins.a0.into_push_pull_output();
+    // RESET pin of Cortex Debug 10-pin connector is negarive logic
+    // https://developer.arm.com/documentation/101453/0100/CoreSight-Technology/Connectors
+    n_reset_pin.set_high().ok();
+
     let swdio = MySwdIoSet::new(
         XiaoSwdInputPin::new(pins.a8.into_floating_input()),
         XiaoSwdInputPin::new(pins.a9.into_floating_input()),
+        XiaoSwdOutputPin::new(n_reset_pin),
         CycleDelay {},
     );
 

--- a/boards/xiao_rp2040/src/main.rs
+++ b/boards/xiao_rp2040/src/main.rs
@@ -42,7 +42,7 @@ mod app {
     #[cfg(feature = "bitbang")]
     type SwdIoSet = rust_dap_rp2040::util::SwdIoSet<GpioSwClk, GpioSwdIo, GpioReset>;
     #[cfg(not(feature = "bitbang"))]
-    type SwdIoSet = rust_dap_rp2040::util::SwdIoSet<GpioSwClk, GpioSwdIo>;
+    type SwdIoSet = rust_dap_rp2040::util::SwdIoSet<GpioSwClk, GpioSwdIo, GpioReset>;
 
     // GPIO mappings
     type GpioSwClk = hal::gpio::bank0::Gpio2;
@@ -174,7 +174,15 @@ mod app {
                 let mut swdio_pin = pins.gpio4.into_mode();
                 swclk_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
                 swdio_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
-                swdio = SwdIoSet::new(c.device.PIO0, swclk_pin, swdio_pin, &mut resets);
+                let mut n_reset_pin = n_reset_pin.into_mode();
+                n_reset_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
+                swdio = SwdIoSet::new(
+                    c.device.PIO0,
+                    swclk_pin,
+                    swdio_pin,
+                    n_reset_pin,
+                    &mut resets,
+                );
             }
             initialize_usb(swdio, usb_allocator, "xiao-rp2040", DapCapabilities::SWD)
         };

--- a/boards/xiao_rp2040/src/main.rs
+++ b/boards/xiao_rp2040/src/main.rs
@@ -153,7 +153,7 @@ mod app {
         let (usb_serial, usb_dap, usb_bus) = {
             // Initialize MCU reset pin.
             let mut n_reset_pin = pins.gpio26.into_push_pull_output();
-            // RESET pin of Cortex Debug 10-pin connector is negarive logic
+            // RESET pin of Cortex Debug 10-pin connector is negative logic
             // https://developer.arm.com/documentation/101453/0100/CoreSight-Technology/Connectors
             n_reset_pin.set_high().ok();
 

--- a/rust-dap-rp2040/src/pio.rs
+++ b/rust-dap-rp2040/src/pio.rs
@@ -14,153 +14,253 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use cortex_m::asm;
+use pio::Program;
 use rust_dap::*;
 // use rust_dap::{SwdIo, SwdIoConfig, SwdRequest, DapError};
 // use rust_dap::{DAP_TRANSFER_OK, DAP_TRANSFER_WAIT, DAP_TRANSFER_FAULT, /* DAP_TRANSFER_ERROR, */ DAP_TRANSFER_MISMATCH};
 use hal::gpio::{bank0, PinId};
-use hal::pac;
-use hal::pio::PIOExt;
+use hal::pac::{self, PIO0};
+use hal::pio::{InstalledProgram, PIOExt};
 use rp2040_hal as hal;
 pub mod pio0 {
     use crate::pio::hal::{self, gpio::FunctionPio0};
     pub type Pin<P> = hal::gpio::Pin<P, FunctionPio0>;
 }
 
+const DEFAULT_CORE_CLOCK: u32 = 125000000;
 const DEFAULT_PIO_DIVISOR: f32 = 1.0f32; // Default PIO Divisor. Generate 125/8 = 15.625[MHz] SWCLK clock.
-const DEFAULT_SWJ_CLOCK_HZ: u32 = ((125000000 / 8) as f32 / DEFAULT_PIO_DIVISOR) as u32;
+                                         // const DEFAULT_SWJ_CLOCK_HZ: u32 = ((DEFAULT_CORE_CLOCK / 8) as f32 / DEFAULT_PIO_DIVISOR) as u32;
+                                         // const SWJ_PINS_CLOCK_DIVIDER: f32 = // set 1us
 
 struct SwdPioContext {
+    pio: hal::pio::PIO<PIO0>,
     running_sm: hal::pio::StateMachine<hal::pio::PIO0SM0, hal::pio::Running>,
     rx_fifo: hal::pio::Rx<hal::pio::PIO0SM0>,
     tx_fifo: hal::pio::Tx<hal::pio::PIO0SM0>,
 }
 
-pub struct SwdIoSet<C, D> {
+pub struct SwdIoSet<C, D, E> {
     clk_pin_id: u8,
     dat_pin_id: u8,
+    rst_pin_id: u8,
     context: Option<SwdPioContext>,
-    _pins: core::marker::PhantomData<(C, D)>,
+    _pins: core::marker::PhantomData<(C, D, E)>,
 }
 
-impl<C, D> SwdIoSet<pio0::Pin<C>, pio0::Pin<D>>
+fn swd_program() -> Program<{ pio::RP2040_MAX_PROGRAM_SIZE }> {
+    type Assembler = pio::Assembler<{ pio::RP2040_MAX_PROGRAM_SIZE }>;
+    let mut a = Assembler::new_with_side_set(pio::SideSet::new(true, 1, false));
+    let mut write_loop = a.label();
+    let mut write_loop_enter = a.label();
+    let mut read_start = a.label();
+    let mut read_loop = a.label();
+    let mut read_loop_enter = a.label();
+    let mut wrap_target = a.label();
+    let mut wrap_source = a.label();
+    const HI: u8 = 1;
+    const LO: u8 = 0;
+    // As we are using side set in optional mode, maximum delay is 7.
+    const Q: u8 = 4 - 1; // delay
+
+    a.bind(&mut wrap_target);
+    // Get number of bits and direction bit from FIFO to OSR.
+    a.pull(false, true);
+    // Move number of bits to X register.
+    a.out(pio::OutDestination::X, 31);
+    // Copy direction bit to Y register.
+    a.mov(
+        pio::MovDestination::Y,
+        pio::MovOperation::None,
+        pio::MovSource::OSR,
+    );
+    // Y == 0 means Read , Y != 0 means Write
+    a.jmp(pio::JmpCondition::YIsZero, &mut read_start);
+
+    // Write-Bits
+    // Get data from FIFO to OSR.
+    a.pull(false, true);
+    // We want to prepare output value before setting pin direction.
+    a.out(pio::OutDestination::PINS, 1);
+    // Use ISP as a temporary store.
+    a.mov(
+        pio::MovDestination::ISR,
+        pio::MovOperation::None,
+        pio::MovSource::OSR,
+    );
+    // Y register has value 1. Copy that 1 to OSR.
+    a.mov(
+        pio::MovDestination::OSR,
+        pio::MovOperation::None,
+        pio::MovSource::Y,
+    );
+    // Set IO direction of SWDIO pin to output.
+    a.out(pio::OutDestination::PINDIRS, 1);
+    // Restore rest of data from ISR to OSR.
+    a.mov(
+        pio::MovDestination::OSR,
+        pio::MovOperation::None,
+        pio::MovSource::ISR,
+    );
+    // Jump if X register is not 0. with post decrement.
+    a.jmp(pio::JmpCondition::XDecNonZero, &mut write_loop_enter);
+
+    // We have updated state of SWDIO pin while keeping SWCLK static.
+    // Start over.
+    a.jmp(pio::JmpCondition::Always, &mut wrap_target);
+
+    a.bind(&mut write_loop);
+    // Output 1-bit. and set SWCLK to High.
+    a.set(pio::SetDestination::PINS, HI);
+    a.out_with_delay(
+        pio::OutDestination::PINS,
+        1,
+        match Q {
+            0 => 0,
+            _ => Q - 1,
+        },
+    );
+    a.bind(&mut write_loop_enter);
+    // Keep looping unless X register is 0. and set SWCLK to Low.
+    a.jmp_with_delay_and_side_set(pio::JmpCondition::XDecNonZero, &mut write_loop, Q, LO);
+    // Set SWCLK to High.
+    a.set(pio::SetDestination::PINS, HI);
+    // Start over.
+    a.jmp(pio::JmpCondition::Always, &mut wrap_target);
+
+    // Read-Bits
+    a.bind(&mut read_start);
+    // Set IO direction of SWDIO pin to input.
+    a.out_with_delay(
+        pio::OutDestination::PINDIRS,
+        1,
+        match Q {
+            0 => 0,
+            _ => Q - 1,
+        },
+    );
+    // Jump if X register is not 0. with post decrement.
+    a.jmp(pio::JmpCondition::XDecNonZero, &mut read_loop_enter);
+    // Wait before reading SWDIO pin.
+    a.nop_with_delay(Q);
+    // Read state of SWDIO pin without clocking SWCLK.
+    a.r#in(pio::InSource::PINS, 1);
+    // Shift in 31 bits of 0 to MSB of ISR.
+    a.r#in(pio::InSource::NULL, 31);
+    // Put result data from ISR to FIFO.
+    a.push(false, true);
+    // Start over.
+    a.jmp(pio::JmpCondition::Always, &mut wrap_target);
+
+    a.bind(&mut read_loop);
+    // Shift-in 1-bit to ISR. and set SWCLK to High.
+    a.r#in_with_delay_and_side_set(pio::InSource::PINS, 1, Q, HI);
+    a.bind(&mut read_loop_enter);
+    // Keep looping unless X register is 0. and set SWCLK to Low.
+    a.jmp_with_delay_and_side_set(pio::JmpCondition::XDecNonZero, &mut read_loop, Q, LO);
+    a.r#in_with_side_set(pio::InSource::PINS, 1, HI);
+    // Put result data from ISR to FIFO.
+    a.push(false, true);
+    a.bind(&mut wrap_source);
+    // Start over.
+    // a.jmp(pio::JmpCondition::Always, &mut wrap_target);
+
+    // The labels wrap_target and wrap_source, as set above,
+    // define a loop which is executed repeatedly by the PIO
+    // state machine.
+    a.assemble_with_wrap(wrap_source, wrap_target)
+}
+
+fn swj_pins_program() -> Program<{ pio::RP2040_MAX_PROGRAM_SIZE }> {
+    type Assembler = pio::Assembler<{ pio::RP2040_MAX_PROGRAM_SIZE }>;
+    let mut a = Assembler::new();
+    let mut delay_loop = a.label();
+    let mut wrap_target = a.label();
+    let mut wrap_source = a.label();
+
+    a.bind(&mut wrap_target);
+
+    // command data
+    // [
+    //      pin_output_values: u32,
+    //      pin_directions: u32,
+    //      wait_us:    u32
+    // ]
+
+    // load and set output value
+    a.pull(false, true);
+    a.out(pio::OutDestination::PINS, 32);
+    // load and set direction
+    a.pull(false, true);
+    a.out(pio::OutDestination::PINDIRS, 32);
+
+    // load output delay to Y
+    a.pull(false, true);
+    a.out(pio::OutDestination::Y, 32);
+
+    // wait_us
+    a.bind(&mut delay_loop);
+    // delay 9(+1) cycles * 0.1us/cycle = 1us
+    a.jmp_with_delay(pio::JmpCondition::YDecNonZero, &mut delay_loop, 9);
+
+    // check all pin status
+    a.r#in(pio::InSource::PINS, 32);
+    a.push(false, true);
+
+    a.bind(&mut wrap_source);
+
+    a.assemble_with_wrap(wrap_source, wrap_target)
+}
+
+fn all_pins_to_input_program() -> Program<{ pio::RP2040_MAX_PROGRAM_SIZE }> {
+    type Assembler = pio::Assembler<{ pio::RP2040_MAX_PROGRAM_SIZE }>;
+    let mut a = Assembler::new();
+    let mut wrap_target = a.label();
+    let mut wrap_source = a.label();
+
+    a.bind(&mut wrap_target);
+
+    a.mov(
+        pio::MovDestination::X,
+        pio::MovOperation::None,
+        pio::MovSource::NULL,
+    );
+    a.out(pio::OutDestination::PINDIRS, 32);
+
+    a.bind(&mut wrap_source);
+
+    a.assemble_with_wrap(wrap_source, wrap_target)
+}
+
+impl<C, D, E> SwdIoSet<pio0::Pin<C>, pio0::Pin<D>, pio0::Pin<E>>
 where
     C: PinId + bank0::BankPinId,
     D: PinId + bank0::BankPinId,
+    E: PinId + bank0::BankPinId,
 {
     #[rustfmt::skip]
-    pub fn new(pio0: pac::PIO0, _: pio0::Pin<C>, _: pio0::Pin<D>, resets: &mut pac::RESETS) -> Self {
+    pub fn new(pio0: pac::PIO0, _: pio0::Pin<C>, _: pio0::Pin<D>, _: pio0::Pin<E>, resets: &mut pac::RESETS) -> Self {
         let clk_pin_id = C::DYN.num;
         let dat_pin_id = D::DYN.num;
+        let rst_pin_id = E::DYN.num;
         // Currently HAL does not provide any way to disable schmitt trigger.
         // unsafe { core::ptr::write_volatile((0x4001C004 + clk_pin_id as u32 * 4) as *mut u32, 0x71 as u32) };
         // unsafe { core::ptr::write_volatile((0x4001C004 + dat_pin_id as u32 * 4) as *mut u32, 0x71 as u32); }
-
-        type Assembler = pio::Assembler<{ pio::RP2040_MAX_PROGRAM_SIZE }>;
-        let mut a = Assembler::new_with_side_set(pio::SideSet::new(true, 1, false));
-        let mut write_loop = a.label();
-        let mut write_loop_enter = a.label();
-        let mut read_start = a.label();
-        let mut read_loop = a.label();
-        let mut read_loop_enter = a.label();
-        let mut wrap_target = a.label();
-        let mut wrap_source = a.label();
-        const HI: u8 = 1;
-        const LO: u8 = 0;
-        // As we are using side set in optional mode, maximum delay is 7.
-        const Q: u8 = 4 - 1; // delay
-
-        a.bind(&mut wrap_target);
-        // Get number of bits and direction bit from FIFO to OSR.
-        a.pull(false, true);
-        // Move number of bits to X register.
-        a.out(pio::OutDestination::X, 31);
-        // Copy direction bit to Y register.
-        a.mov(pio::MovDestination::Y, pio::MovOperation::None, pio::MovSource::OSR);
-        // Y == 0 means Read , Y != 0 means Write
-        a.jmp(pio::JmpCondition::YIsZero, &mut read_start);
-
-        // Write-Bits
-        // Get data from FIFO to OSR.
-        a.pull(false, true);
-        // We want to prepare output value before setting pin direction.
-        a.out(pio::OutDestination::PINS, 1);
-        // Use ISP as a temporary store.
-        a.mov(pio::MovDestination::ISR, pio::MovOperation::None, pio::MovSource::OSR);
-        // Y register has value 1. Copy that 1 to OSR.
-        a.mov(pio::MovDestination::OSR, pio::MovOperation::None, pio::MovSource::Y);
-        // Set IO direction of SWDIO pin to output.
-        a.out(pio::OutDestination::PINDIRS, 1);
-        // Restore rest of data from ISR to OSR.
-        a.mov(pio::MovDestination::OSR, pio::MovOperation::None, pio::MovSource::ISR);
-        // Jump if X register is not 0. with post decrement.
-        a.jmp(pio::JmpCondition::XDecNonZero, &mut write_loop_enter);
-
-        // We have updated state of SWDIO pin while keeping SWCLK static.
-        // Start over.
-        a.jmp(pio::JmpCondition::Always, &mut wrap_target);
-
-        a.bind(&mut write_loop);
-        // Output 1-bit. and set SWCLK to High.
-        a.set(pio::SetDestination::PINS, HI);
-        a.out_with_delay(pio::OutDestination::PINS, 1, match Q { 0 => 0, _ => Q - 1 });
-        a.bind(&mut write_loop_enter);
-        // Keep looping unless X register is 0. and set SWCLK to Low.
-        a.jmp_with_delay_and_side_set(pio::JmpCondition::XDecNonZero, &mut write_loop, Q, LO);
-        // Set SWCLK to High.
-        a.set(pio::SetDestination::PINS, HI);
-        // Start over.
-        a.jmp(pio::JmpCondition::Always, &mut wrap_target);
-
-        // Read-Bits
-        a.bind(&mut read_start);
-        // Set IO direction of SWDIO pin to input.
-        a.out_with_delay(pio::OutDestination::PINDIRS, 1, match Q { 0 => 0, _ => Q - 1 });
-        // Jump if X register is not 0. with post decrement.
-        a.jmp(pio::JmpCondition::XDecNonZero, &mut read_loop_enter);
-        // Wait before reading SWDIO pin.
-        a.nop_with_delay(Q);
-        // Read state of SWDIO pin without clocking SWCLK.
-        a.r#in(pio::InSource::PINS, 1);
-        // Shift in 31 bits of 0 to MSB of ISR.
-        a.r#in(pio::InSource::NULL, 31);
-        // Put result data from ISR to FIFO.
-        a.push(false, true);
-        // Start over.
-        a.jmp(pio::JmpCondition::Always, &mut wrap_target);
-
-        a.bind(&mut read_loop);
-        // Shift-in 1-bit to ISR. and set SWCLK to High.
-        a.r#in_with_delay_and_side_set(pio::InSource::PINS, 1, Q, HI);
-        a.bind(&mut read_loop_enter);
-        // Keep looping unless X register is 0. and set SWCLK to Low.
-        a.jmp_with_delay_and_side_set(pio::JmpCondition::XDecNonZero, &mut read_loop, Q, LO);
-        a.r#in_with_side_set(pio::InSource::PINS, 1, HI);
-        // Put result data from ISR to FIFO.
-        a.push(false, true);
-        a.bind(&mut wrap_source);
-        // Start over.
-        // a.jmp(pio::JmpCondition::Always, &mut wrap_target);
-
-        // The labels wrap_target and wrap_source, as set above,
-        // define a loop which is executed repeatedly by the PIO
-        // state machine.
-        let program = a.assemble_with_wrap(wrap_source, wrap_target);
-        // let program = a.assemble_program();
-        // let program = program.set_origin(Some(0));
+        let program = all_pins_to_input_program();
 
         // Initialize and start PIO
+        // install swj_pin to pull-up RESET PIN
         let (mut pio, sm0, _, _, _) = pio0.split(resets);
         let installed = pio.install(&program).unwrap();
-        let (sm, rx, tx) = Self::build_pio(clk_pin_id, dat_pin_id, installed, DEFAULT_PIO_DIVISOR, sm0);
-        // Pin modes are controlled in connect() and disconnect() .
-        // sm.set_pindirs([(clk_pin_id, hal::pio::PinDir::Output), (dat_pin_id, hal::pio::PinDir::Output)]);
-
+        let (sm, rx, tx) = Self::build_pio((0,32) ,0, (0,32),0, installed, DEFAULT_PIO_DIVISOR, sm0);
         let running_sm = sm.start();
 
         Self {
             clk_pin_id,
             dat_pin_id,
+            rst_pin_id,
             context: Some(SwdPioContext {
+                pio,
                 running_sm,
                 rx_fifo: rx,
                 tx_fifo: tx,
@@ -171,7 +271,7 @@ where
 }
 
 // Auxiliary low-level function
-impl<C, D> SwdIoSet<C, D> {
+impl<C, D, E> SwdIoSet<C, D, E> {
     fn get_context(&mut self) -> &mut SwdPioContext {
         self.context.as_mut().unwrap()
     }
@@ -190,9 +290,11 @@ impl<C, D> SwdIoSet<C, D> {
     }
 
     fn build_pio<P: PIOExt>(
-        clk_pin_id: u8,
-        dat_pin_id: u8,
-        installed: hal::pio::InstalledProgram<P>,
+        (set_pin_id, set_pin_count): (u8, u8),
+        side_set_pin_id: u8,
+        (out_pins_id, out_pins_count): (u8, u8),
+        in_pins_id: u8,
+        installed: InstalledProgram<P>,
         divisor: f32,
         sm0: hal::pio::UninitStateMachine<(P, hal::pio::SM0)>,
     ) -> (
@@ -201,11 +303,11 @@ impl<C, D> SwdIoSet<C, D> {
         hal::pio::Tx<(P, hal::pio::SM0)>,
     ) {
         hal::pio::PIOBuilder::from_program(installed)
-            .set_pins(clk_pin_id, 1)
-            .side_set_pin_base(clk_pin_id)
-            .out_pins(dat_pin_id, 1)
+            .set_pins(set_pin_id, set_pin_count)
+            .side_set_pin_base(side_set_pin_id)
+            .out_pins(out_pins_id, out_pins_count)
             .out_shift_direction(hal::pio::ShiftDirection::Right)
-            .in_pin_base(dat_pin_id)
+            .in_pin_base(in_pins_id)
             .in_shift_direction(hal::pio::ShiftDirection::Right)
             .clock_divisor(divisor)
             .build(sm0)
@@ -214,7 +316,7 @@ impl<C, D> SwdIoSet<C, D> {
     fn set_clock(&mut self, frequency_hz: u32) {
         // Calculate divisor.
         let divisor = if frequency_hz > 0 {
-            ((125000000u32 / 8) / frequency_hz) as f32
+            ((DEFAULT_CORE_CLOCK / 8) / frequency_hz) as f32
         } else {
             DEFAULT_PIO_DIVISOR
         };
@@ -230,7 +332,9 @@ impl<C, D> SwdIoSet<C, D> {
         let context = context.unwrap();
         let (sm0, installed) = context.running_sm.uninit(context.rx_fifo, context.tx_fifo);
         let (sm0, rx_fifo, tx_fifo) = Self::build_pio(
+            (self.clk_pin_id, 1),
             self.clk_pin_id,
+            (self.dat_pin_id, 1),
             self.dat_pin_id,
             installed,
             divisor as f32,
@@ -238,6 +342,90 @@ impl<C, D> SwdIoSet<C, D> {
         );
         let running_sm = sm0.start();
         let mut new_context = Some(SwdPioContext {
+            pio: context.pio,
+            running_sm,
+            rx_fifo,
+            tx_fifo,
+        });
+        core::mem::swap(&mut self.context, &mut new_context);
+    }
+
+    fn setup_swd(&mut self) {
+        // Stop SM, Reconstruct SM with new program.
+        let mut context = None;
+        core::mem::swap(&mut self.context, &mut context);
+        let context = context.unwrap();
+        let (sm0, installed) = context.running_sm.uninit(context.rx_fifo, context.tx_fifo);
+        let mut pio = context.pio;
+        pio.uninstall(installed);
+        let installed = pio.install(&swd_program()).unwrap();
+        let (sm0, rx_fifo, tx_fifo) = Self::build_pio(
+            (self.clk_pin_id, 1),
+            self.clk_pin_id,
+            (self.dat_pin_id, 1),
+            self.dat_pin_id,
+            installed,
+            DEFAULT_PIO_DIVISOR,
+            sm0,
+        );
+        let running_sm = sm0.start();
+        let mut new_context = Some(SwdPioContext {
+            pio,
+            running_sm,
+            rx_fifo,
+            tx_fifo,
+        });
+        core::mem::swap(&mut self.context, &mut new_context);
+    }
+
+    fn setup_all_pins_to_input_program(&mut self) {
+        // Stop SM, Reconstruct SM with new program.
+        let mut context = None;
+        core::mem::swap(&mut self.context, &mut context);
+        let context = context.unwrap();
+        let (sm0, installed) = context.running_sm.uninit(context.rx_fifo, context.tx_fifo);
+        let mut pio = context.pio;
+        pio.uninstall(installed);
+        let installed = pio.install(&all_pins_to_input_program()).unwrap();
+        let (sm0, rx_fifo, tx_fifo) = Self::build_pio(
+            (self.clk_pin_id, 1),
+            self.clk_pin_id,
+            (self.dat_pin_id, 1),
+            self.dat_pin_id,
+            installed,
+            DEFAULT_PIO_DIVISOR,
+            sm0,
+        );
+        let running_sm = sm0.start();
+        let mut new_context = Some(SwdPioContext {
+            pio,
+            running_sm,
+            rx_fifo,
+            tx_fifo,
+        });
+        core::mem::swap(&mut self.context, &mut new_context);
+    }
+
+    fn setup_swj_pins(&mut self) {
+        // Calculate divisor.
+        // set 0.1us = 10 MHz
+        // core frequency(MHz) / 100(MHz) = 0.1us/clock
+        let system_clock = f32::try_from((DEFAULT_CORE_CLOCK / 1_000_000) as u16).unwrap();
+        let divisor = system_clock / 10f32;
+
+        // Stop SM, Reconstruct SM with new program.
+        let mut context = None;
+        core::mem::swap(&mut self.context, &mut context);
+        let context = context.unwrap();
+        let (sm0, installed) = context.running_sm.uninit(context.rx_fifo, context.tx_fifo);
+        let mut pio = context.pio;
+        pio.uninstall(installed);
+        let installed = pio.install(&swj_pins_program()).unwrap();
+        let (sm0, rx_fifo, tx_fifo) =
+            Self::build_pio((0, 1), 0, (0, 32), 0, installed, divisor as f32, sm0);
+        let running_sm = sm0.start();
+        let mut new_context = Some(SwdPioContext {
+            pio,
             running_sm,
             rx_fifo,
             tx_fifo,
@@ -247,14 +435,14 @@ impl<C, D> SwdIoSet<C, D> {
 }
 
 // Connect and disconnect function
-impl<C, D> SwdIoSet<C, D> {
+impl<C, D, E> SwdIoSet<C, D, E> {
     fn connect(&mut self) {
+        self.setup_swd();
         self.set_clk_pindir(true);
         self.to_swdio_out(true);
     }
     fn disconnect(&mut self) {
-        self.to_swdio_in();
-        self.set_clk_pindir(false);
+        self.setup_all_pins_to_input_program();
         // Reset clock
         #[cfg(feature = "set_clock")]
         self.set_clock(DEFAULT_SWJ_CLOCK_HZ);
@@ -262,7 +450,7 @@ impl<C, D> SwdIoSet<C, D> {
 }
 
 // Basis of SWD interface
-impl<C, D> SwdIoSet<C, D> {
+impl<C, D, E> SwdIoSet<C, D, E> {
     // if bits > 32 , it will behave as if value is extended with zeros.
     fn write_bits(&mut self, bits: u32, value: u32) {
         while !self.get_context().tx_fifo.write(bits | 1 << 31) {}
@@ -279,7 +467,7 @@ impl<C, D> SwdIoSet<C, D> {
 }
 
 // Supplemental functions for SWD
-impl<C, D> SwdIoSet<C, D> {
+impl<C, D, E> SwdIoSet<C, D, E> {
     #[allow(clippy::wrong_self_convention)]
     fn to_swdio_in(&mut self) {
         self.read_bits(0);
@@ -319,7 +507,7 @@ pub trait SupplementSwdIo {
 }
 */
 
-impl<C, D> SwdIo for SwdIoSet<C, D> {
+impl<C, D, E> SwdIo for SwdIoSet<C, D, E> {
     fn connect(&mut self) {
         self.connect();
     }
@@ -473,7 +661,7 @@ impl<C, D> SwdIo for SwdIoSet<C, D> {
     }
 }
 
-impl<C, D> CmsisDapCommandInner for SwdIoSet<C, D> {
+impl<C, D, E> CmsisDapCommandInner for SwdIoSet<C, D, E> {
     fn connect(&mut self, _config: &CmsisDapConfig) {
         SwdIo::connect(self);
     }
@@ -571,12 +759,83 @@ impl<C, D> CmsisDapCommandInner for SwdIoSet<C, D> {
     fn swj_pins(
         &mut self,
         _config: &CmsisDapConfig,
-        _pin_output: u8,
-        _pin_select: u8,
-        _wait_us: u32,
+        pin_output: u8,
+        pin_select: u8,
+        wait_us: u32,
     ) -> core::result::Result<u8, DapError> {
-        // TODO: write
-        Ok(0)
+        // install swj_pins program
+        self.setup_swj_pins();
+
+        // clean rx fifo
+        while !self.get_context().rx_fifo.is_empty() {
+            let _ = self.get_context().rx_fifo.read();
+        }
+
+        let pin_output = SwjPins::from_bits(pin_output).unwrap();
+        let pin_select = SwjPins::from_bits(pin_select).unwrap();
+
+        // output
+        let mut pio_pin_out: u32 = 0;
+        if pin_select.contains(SwjPins::TCK_SWDCLK) {
+            pio_pin_out |= if pin_output.contains(SwjPins::TCK_SWDCLK) {
+                1
+            } else {
+                0
+            } << self.clk_pin_id;
+        }
+        if pin_select.contains(SwjPins::TMS_SWDIO) {
+            pio_pin_out |= if pin_output.contains(SwjPins::TMS_SWDIO) {
+                1
+            } else {
+                0
+            } << self.dat_pin_id;
+        }
+        if pin_select.contains(SwjPins::N_RESET) {
+            pio_pin_out |= if pin_output.contains(SwjPins::N_RESET) {
+                1
+            } else {
+                0
+            } << self.rst_pin_id;
+        }
+        self.context.as_mut().unwrap().tx_fifo.write(pio_pin_out);
+
+        // directions
+        let pio_pin_directions = 1 << self.clk_pin_id | 0 << self.dat_pin_id | 1 << self.rst_pin_id;
+        // let pio_pin_directions:u32 = 0;
+        self.context
+            .as_mut()
+            .unwrap()
+            .tx_fifo
+            .write(pio_pin_directions);
+
+        // wait_us
+        self.context.as_mut().unwrap().tx_fifo.write(wait_us);
+
+        // input
+        let tmp = loop {
+            if let Some(x) = self.context.as_mut().unwrap().rx_fifo.read() {
+                break x;
+            } else {
+                asm::nop();
+            };
+        };
+
+        // convert
+        let mut input = SwjPins::empty();
+        if tmp & (1 << self.clk_pin_id) != 0 {
+            input |= SwjPins::TCK_SWDCLK;
+        }
+        if tmp & (1 << self.dat_pin_id) != 0 {
+            input |= SwjPins::TMS_SWDIO;
+        }
+        if tmp & (1 << self.rst_pin_id) != 0 {
+            input |= SwjPins::N_RESET;
+        }
+
+        // restore SWD program
+        self.setup_swd();
+
+        Ok(input.bits())
     }
 
     fn jtag_idcode(

--- a/rust-dap-rp2040/src/pio.rs
+++ b/rust-dap-rp2040/src/pio.rs
@@ -254,7 +254,7 @@ where
         // install swj_pin to pull-up RESET PIN
         let (mut pio, sm0, _, _, _) = pio0.split(resets);
         let installed = pio.install(&program).unwrap();
-        let (sm, rx, tx) = Self::build_pio((0,32) ,0, (0,32),0, installed, DEFAULT_PIO_DIVISOR, sm0);
+        let (sm, rx, tx) = Self::build_pio((0,5) ,0, (0,32),0, installed, DEFAULT_PIO_DIVISOR, sm0);
         let running_sm = sm.start();
 
         Self {

--- a/rust-dap-rp2040/src/util.rs
+++ b/rust-dap-rp2040/src/util.rs
@@ -30,11 +30,13 @@ use crate::swdio_pin::{PicoSwdInputPin, PicoSwdOutputPin};
 #[cfg(feature = "bitbang")]
 use rust_dap::bitbang::{DelayFunc, JtagIoSet as BitbangJtagIoSet, SwdIoSet as BitbangSwdIoSet};
 #[cfg(feature = "bitbang")]
-pub type SwdIoSet<C, D> = BitbangSwdIoSet<
+pub type SwdIoSet<C, D, E> = BitbangSwdIoSet<
     PicoSwdInputPin<C>,
     PicoSwdOutputPin<C>,
     PicoSwdInputPin<D>,
     PicoSwdOutputPin<D>,
+    PicoSwdInputPin<E>,
+    PicoSwdOutputPin<E>,
     CycleDelay,
 >;
 #[cfg(feature = "bitbang")]

--- a/rust-dap-rp2040/src/util.rs
+++ b/rust-dap-rp2040/src/util.rs
@@ -59,7 +59,7 @@ pub type JtagIoSet<TCK, TMS, TDI, TDO, TRST, SRST> = BitbangJtagIoSet<
 #[cfg(not(feature = "bitbang"))]
 use crate::pio::{pio0, SwdIoSet as PioSwdIoSet};
 #[cfg(not(feature = "bitbang"))]
-pub type SwdIoSet<C, D> = PioSwdIoSet<pio0::Pin<C>, pio0::Pin<D>>;
+pub type SwdIoSet<C, D, E> = PioSwdIoSet<pio0::Pin<C>, pio0::Pin<D>, pio0::Pin<E>>;
 
 /// DelayFunc implementation which uses cortex_m::asm::delay
 #[cfg(feature = "bitbang")]

--- a/rust-dap/src/bitbang.rs
+++ b/rust-dap/src/bitbang.rs
@@ -15,28 +15,7 @@
 // limitations under the License.
 
 use crate::cmsis_dap::*;
-use bitflags::bitflags;
 use embedded_hal::digital::v2::{InputPin, IoPin, OutputPin, PinState};
-
-// Bit 0: SWCLK/TCK
-// Bit 1: SWDIO/TMS
-// Bit 2: TDI
-// Bit 3: TDO
-// Bit 5: nTRST
-// Bit 7: nRESET
-// https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__SWJ__Pins.html
-bitflags! {
-    struct SwjPins: u8 {
-        const TCK_SWDCLK = 1 << 0;
-        const TMS_SWDIO  = 1 << 1;
-        const TDI        = 1 << 2;
-        const TDO        = 1 << 3;
-        const UNKNOWN4   = 1 << 4;
-        const N_TRST     = 1 << 5;
-        const UNKNOWN6   = 1 << 6;
-        const N_RESET    = 1 << 7;
-    }
-}
 
 pub trait DelayFunc {
     fn calculate_half_clock_cycles(_frequency_hz: u32) -> Option<u32> {

--- a/rust-dap/src/bitbang.rs
+++ b/rust-dap/src/bitbang.rs
@@ -27,12 +27,14 @@ use embedded_hal::digital::v2::{InputPin, IoPin, OutputPin, PinState};
 // https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__SWJ__Pins.html
 bitflags! {
     struct SwjPins: u8 {
-        const TCK_SWDCLK = 1;
-        const TMS_SWDIO = 1 << 1;
-        const TDI = 1 << 2;
-        const TDO = 1 << 3;
-        const N_TRST = 1 << 5;
-        const N_RESET = 1 << 7;
+        const TCK_SWDCLK = 1 << 0;
+        const TMS_SWDIO  = 1 << 1;
+        const TDI        = 1 << 2;
+        const TDO        = 1 << 3;
+        const UNKNOWN4   = 1 << 4;
+        const N_TRST     = 1 << 5;
+        const UNKNOWN6   = 1 << 6;
+        const N_RESET    = 1 << 7;
     }
 }
 
@@ -105,48 +107,102 @@ fn get_input<I: InputPin + IoPin<I, O>, O: OutputPin + IoPin<I, O>>(
 ///////////////////
 /////// SWD ///////
 ///////////////////
-pub struct SwdIoSet<SwClkInputPin, SwClkOutputPin, SwdIoInputPin, SwdIoOutputPin, DelayFn>
-where
+pub struct SwdIoSet<
+    SwClkInputPin,
+    SwClkOutputPin,
+    SwdIoInputPin,
+    SwdIoOutputPin,
+    ResetInputPin,
+    ResetOutputPin,
+    DelayFn,
+> where
     SwClkInputPin: InputPin + IoPin<SwClkInputPin, SwClkOutputPin>,
     SwClkOutputPin: OutputPin + IoPin<SwClkInputPin, SwClkOutputPin>,
     SwdIoInputPin: InputPin + IoPin<SwdIoInputPin, SwdIoOutputPin>,
     SwdIoOutputPin: OutputPin + IoPin<SwdIoInputPin, SwdIoOutputPin>,
+    ResetInputPin: InputPin + IoPin<ResetInputPin, ResetOutputPin>,
+    ResetOutputPin: OutputPin + IoPin<ResetInputPin, ResetOutputPin>,
     DelayFn: DelayFunc,
 {
     swdio_in: Option<SwdIoInputPin>,
     swdio_out: Option<SwdIoOutputPin>,
     swclk_in: Option<SwClkInputPin>,
     swclk_out: Option<SwClkOutputPin>,
+    reset_in: Option<ResetInputPin>,
+    reset_out: Option<ResetOutputPin>,
     cycle_delay: DelayFn,
 }
 
-impl<SwClkInputPin, SwClkOutputPin, SwdIoInputPin, SwdIoOutputPin, DelayFn>
-    SwdIoSet<SwClkInputPin, SwClkOutputPin, SwdIoInputPin, SwdIoOutputPin, DelayFn>
+impl<
+        SwClkInputPin,
+        SwClkOutputPin,
+        SwdIoInputPin,
+        SwdIoOutputPin,
+        ResetInputPin,
+        ResetOutputPin,
+        DelayFn,
+    >
+    SwdIoSet<
+        SwClkInputPin,
+        SwClkOutputPin,
+        SwdIoInputPin,
+        SwdIoOutputPin,
+        ResetInputPin,
+        ResetOutputPin,
+        DelayFn,
+    >
 where
     SwClkInputPin: InputPin + IoPin<SwClkInputPin, SwClkOutputPin>,
     SwClkOutputPin: OutputPin + IoPin<SwClkInputPin, SwClkOutputPin>,
     SwdIoInputPin: InputPin + IoPin<SwdIoInputPin, SwdIoOutputPin>,
     SwdIoOutputPin: OutputPin + IoPin<SwdIoInputPin, SwdIoOutputPin>,
+    ResetInputPin: InputPin + IoPin<ResetInputPin, ResetOutputPin>,
+    ResetOutputPin: OutputPin + IoPin<ResetInputPin, ResetOutputPin>,
     DelayFn: DelayFunc,
 {
-    pub fn new(swclk: SwClkInputPin, swdio: SwdIoInputPin, cycle_delay: DelayFn) -> Self {
+    pub fn new(
+        swclk: SwClkInputPin,
+        swdio: SwdIoInputPin,
+        reset: ResetOutputPin,
+        cycle_delay: DelayFn,
+    ) -> Self {
         Self {
             swdio_in: Some(swdio),
             swdio_out: None,
             swclk_in: Some(swclk),
             swclk_out: None,
+            reset_in: None,
+            reset_out: Some(reset),
             cycle_delay,
         }
     }
 }
 
-impl<SwClkInputPin, SwClkOutputPin, SwdIoInputPin, SwdIoOutputPin, DelayFn> BitBangSwdIo
-    for SwdIoSet<SwClkInputPin, SwClkOutputPin, SwdIoInputPin, SwdIoOutputPin, DelayFn>
+impl<
+        SwClkInputPin,
+        SwClkOutputPin,
+        SwdIoInputPin,
+        SwdIoOutputPin,
+        ResetInputPin,
+        ResetOutputPin,
+        DelayFn,
+    > BitBangSwdIo
+    for SwdIoSet<
+        SwClkInputPin,
+        SwClkOutputPin,
+        SwdIoInputPin,
+        SwdIoOutputPin,
+        ResetInputPin,
+        ResetOutputPin,
+        DelayFn,
+    >
 where
     SwClkInputPin: InputPin + IoPin<SwClkInputPin, SwClkOutputPin>,
     SwClkOutputPin: OutputPin + IoPin<SwClkInputPin, SwClkOutputPin>,
     SwdIoInputPin: InputPin + IoPin<SwdIoInputPin, SwdIoOutputPin>,
     SwdIoOutputPin: OutputPin + IoPin<SwdIoInputPin, SwdIoOutputPin>,
+    ResetInputPin: InputPin + IoPin<ResetInputPin, ResetOutputPin>,
+    ResetOutputPin: OutputPin + IoPin<ResetInputPin, ResetOutputPin>,
     DelayFn: DelayFunc,
 {
     fn calculate_half_clock_cycles(frequency_hz: u32) -> Option<u32> {
@@ -207,6 +263,33 @@ where
             );
         }
     }
+    fn to_reset_in(&mut self) {
+        let mut pin = None;
+        core::mem::swap(&mut pin, &mut self.reset_out);
+        if let Some(reset_out) = pin {
+            self.reset_in = Some(
+                reset_out
+                    .into_input_pin()
+                    .unwrap_or_else(|_| panic!("Failed to turn RESET pin to input.")),
+            );
+        }
+    }
+    fn to_reset_out(&mut self, output: bool) {
+        let mut pin = None;
+        core::mem::swap(&mut pin, &mut self.reset_in);
+        if let Some(reset_in) = pin {
+            let state = if output {
+                PinState::High
+            } else {
+                PinState::Low
+            };
+            self.reset_out = Some(
+                reset_in
+                    .into_output_pin(state)
+                    .unwrap_or_else(|_| panic!("Failed to turn RESET pin to output.")),
+            );
+        }
+    }
     fn set_swclk_output(&mut self, output: bool) {
         self.swclk_out.as_mut().and_then(|p| {
             if output {
@@ -225,8 +308,29 @@ where
             }
         });
     }
+    fn set_reset_output(&mut self, output: bool) {
+        self.reset_out.as_mut().and_then(|p| {
+            if output {
+                p.set_high().ok()
+            } else {
+                p.set_low().ok()
+            }
+        });
+    }
     fn get_swdio_input(&mut self) -> bool {
         self.swdio_in
+            .as_mut()
+            .map(|p| p.is_high().unwrap_or(false))
+            .unwrap()
+    }
+    fn get_swclk_input(&mut self) -> bool {
+        self.swclk_in
+            .as_mut()
+            .map(|p| p.is_high().unwrap_or(false))
+            .unwrap()
+    }
+    fn get_reset_input(&mut self) -> bool {
+        self.reset_in
             .as_mut()
             .map(|p| p.is_high().unwrap_or(false))
             .unwrap()
@@ -240,14 +344,18 @@ pub trait BitBangSwdIo {
     fn calculate_half_clock_cycles(_frequency_hz: u32) -> Option<u32> {
         None
     }
-
     fn to_swclk_in(&mut self);
     fn to_swclk_out(&mut self, output: bool);
     fn to_swdio_in(&mut self);
     fn to_swdio_out(&mut self, output: bool);
+    fn to_reset_in(&mut self);
+    fn to_reset_out(&mut self, output: bool);
     fn set_swclk_output(&mut self, output: bool);
     fn set_swdio_output(&mut self, output: bool);
+    fn set_reset_output(&mut self, output: bool);
+    fn get_swclk_input(&mut self) -> bool;
     fn get_swdio_input(&mut self) -> bool;
+    fn get_reset_input(&mut self) -> bool;
     fn clock_wait(&self, config: &SwdIoConfig);
 }
 
@@ -522,13 +630,31 @@ impl<Io: PrimitiveSwdIo> SwdIo for Io {
     }
 }
 
-impl<SwClkInputPin, SwClkOutputPin, SwdIoInputPin, SwdIoOutputPin, DelayFn> CmsisDapCommandInner
-    for SwdIoSet<SwClkInputPin, SwClkOutputPin, SwdIoInputPin, SwdIoOutputPin, DelayFn>
+impl<
+        SwClkInputPin,
+        SwClkOutputPin,
+        SwdIoInputPin,
+        SwdIoOutputPin,
+        ResetInputPin,
+        ResetOutputPin,
+        DelayFn,
+    > CmsisDapCommandInner
+    for SwdIoSet<
+        SwClkInputPin,
+        SwClkOutputPin,
+        SwdIoInputPin,
+        SwdIoOutputPin,
+        ResetInputPin,
+        ResetOutputPin,
+        DelayFn,
+    >
 where
     SwClkInputPin: InputPin + IoPin<SwClkInputPin, SwClkOutputPin>,
     SwClkOutputPin: OutputPin + IoPin<SwClkInputPin, SwClkOutputPin>,
     SwdIoInputPin: InputPin + IoPin<SwdIoInputPin, SwdIoOutputPin>,
     SwdIoOutputPin: OutputPin + IoPin<SwdIoInputPin, SwdIoOutputPin>,
+    ResetInputPin: InputPin + IoPin<ResetInputPin, ResetOutputPin>,
+    ResetOutputPin: OutputPin + IoPin<ResetInputPin, ResetOutputPin>,
     DelayFn: DelayFunc,
 {
     fn connect(&mut self, _config: &CmsisDapConfig) {
@@ -620,12 +746,94 @@ where
     fn swj_pins(
         &mut self,
         _config: &CmsisDapConfig,
-        _pin_output: u8,
-        _pin_select: u8,
-        _wait_us: u32,
+        pin_output: u8,
+        pin_select: u8,
+        wait_us: u32,
     ) -> core::result::Result<u8, DapError> {
-        // TODO: write
-        Ok(0)
+        let pin_output = SwjPins::from_bits(pin_output).unwrap();
+        let pin_select = SwjPins::from_bits(pin_select).unwrap();
+
+        let flags = [
+            SwjPins::TCK_SWDCLK,
+            SwjPins::TMS_SWDIO,
+            SwjPins::TDI,
+            SwjPins::TDO,
+            SwjPins::N_TRST,
+            SwjPins::N_RESET,
+        ];
+
+        // output
+        for f in flags {
+            if pin_select.contains(f) {
+                let output = pin_output.contains(f);
+                match f {
+                    SwjPins::TCK_SWDCLK => {
+                        // TODO: inputならoutputにする
+                        // TODO: outputする値を覚えておいて、最後にもとに戻す
+                        self.set_swclk_output(output);
+                    }
+                    SwjPins::TMS_SWDIO => {
+                        self.set_swdio_output(output);
+                    }
+                    SwjPins::N_RESET => {
+                        self.set_reset_output(output);
+                    }
+                    _ => (),
+                }
+            }
+        }
+
+        // FIXIT: get core clock from system
+        // CORE_CLOCK / 1000000 * wait_us
+        const CORE_CLOCK: u64 = 125000000;
+        self.cycle_delay
+            .cycle_delay((CORE_CLOCK * wait_us as u64 / 1000000u64) as u32);
+
+        // backup
+        let swclk_is_output = self.swclk_out.is_some();
+        let swdio_is_output = self.swdio_out.is_some();
+        let n_reset_is_output = self.reset_out.is_some();
+
+        // change io
+        if swclk_is_output {
+            self.to_swclk_in();
+        }
+        if swdio_is_output {
+            self.to_swdio_in();
+        }
+        if n_reset_is_output {
+            self.to_reset_in();
+        }
+
+        // input
+        let mut pin_input = if self.get_swclk_input() {
+            SwjPins::TCK_SWDCLK
+        } else {
+            SwjPins::empty()
+        };
+        pin_input |= if self.get_swdio_input() {
+            SwjPins::TMS_SWDIO
+        } else {
+            SwjPins::empty()
+        };
+        pin_input |= if self.get_reset_input() {
+            SwjPins::N_RESET
+        } else {
+            SwjPins::empty()
+        };
+
+        // restore io
+        if swclk_is_output {
+            self.to_swclk_out(false);
+        }
+        if swdio_is_output {
+            self.to_swdio_out(false);
+        }
+        if n_reset_is_output {
+            self.to_reset_out(true);
+        }
+
+        Ok(pin_input.bits())
     }
 
     fn swj_clock(

--- a/rust-dap/src/cmsis_dap.rs
+++ b/rust-dap/src/cmsis_dap.rs
@@ -93,6 +93,26 @@ bitflags! {
     }
 }
 
+// Bit 0: SWCLK/TCK
+// Bit 1: SWDIO/TMS
+// Bit 2: TDI
+// Bit 3: TDO
+// Bit 5: nTRST
+// Bit 7: nRESET
+// https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__SWJ__Pins.html
+bitflags! {
+    pub struct SwjPins: u8 {
+        const TCK_SWDCLK = 1 << 0;
+        const TMS_SWDIO  = 1 << 1;
+        const TDI        = 1 << 2;
+        const TDO        = 1 << 3;
+        const UNKNOWN4   = 1 << 4;
+        const N_TRST     = 1 << 5;
+        const UNKNOWN6   = 1 << 6;
+        const N_RESET    = 1 << 7;
+    }
+}
+
 pub const DAP_TRANSFER_OK: u8 = 0x01;
 pub const DAP_TRANSFER_WAIT: u8 = 0x02;
 pub const DAP_TRANSFER_FAULT: u8 = 0x04;


### PR DESCRIPTION
https://github.com/ciniml/rust-dap/pull/54 の続きです。

pioでもnRESETを使えるようにしてみました。

動作確認方法は #54 と同様です。

# 課題

- bitbangでwait_usが正しく動かない（考慮不要？ https://github.com/ciniml/rust-dap/pull/54#issuecomment-1694222592)
- bitbangとpioでswj_pinsの挙動が異なる
    - bitbangはSWJ_PinsコマンドのPin Selectで指定されたpinのdirectionを変更する
    - PIOはpinのdirectionを変更しない（こちらの方がDAP Linkのコードの挙動に近いはずですが、誤りがあれば教えてください）