### PR TITLE
initial support for JTAG using PIO

### DIFF
--- a/boards/rpi_pico/Cargo.lock
+++ b/boards/rpi_pico/Cargo.lock
@@ -547,6 +547,7 @@ dependencies = [
 name = "rust-dap-rp2040"
 version = "0.2.0"
 dependencies = [
+ "bitvec",
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-rtic",

--- a/boards/rpi_pico/Cargo.lock
+++ b/boards/rpi_pico/Cargo.lock
@@ -51,6 +51,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +224,12 @@ checksum = "17186ad64927d5ac8f02c1e77ccefa08ccd9eaa314d5a4772278aa204a22f7e7"
 dependencies = [
  "gcd",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "gcd"
@@ -387,6 +405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +513,7 @@ name = "rust-dap"
 version = "0.2.0"
 dependencies = [
  "bitflags",
+ "bitvec",
  "defmt",
  "embedded-hal",
  "heapless",
@@ -622,6 +647,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "thiserror"
 version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,4 +720,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]

--- a/boards/rpi_pico/Cargo.toml
+++ b/boards/rpi_pico/Cargo.toml
@@ -26,7 +26,7 @@ bitbang = ["rust-dap/bitbang", "rust-dap-rp2040/bitbang"]
 set_clock = [
     "rust-dap-rp2040/set_clock",
 ] # Enable swj_clock implementation for PIO and set appropriate SWCLK frequency. Otherwise, SWCLK is fixed to 15.625[MHz]
-jtag = ["bitbang"]
+jtag = []
 swd = []
 swj = []
 ram-exec = ["rust-dap-rp2040/ram-exec"] # Execute-in-SRAM support

--- a/boards/rpi_pico/src/main.rs
+++ b/boards/rpi_pico/src/main.rs
@@ -247,8 +247,34 @@ mod app {
                     trst_pin,
                     srst_pin,
                     CycleDelay {},
-                );
-            }
+                )
+            };
+            #[cfg(not(feature = "bitbang"))]
+            {
+                // PIO
+                let mut tck_pin = pins.gpio2.into_mode();
+                let mut tms_pin = pins.gpio3.into_mode();
+                let mut tdo_pin = pins.gpio5.into_mode();
+                let mut tdi_pin = pins.gpio6.into_mode();
+                let mut trst_pin = pins.gpio7.into_mode();
+                let mut srst_pin = pins.gpio4.into_mode();
+                tck_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
+                tms_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
+                tdo_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
+                tdi_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
+                trst_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
+                srst_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
+                jtagio = JtagIoSet::new(
+                    c.device.PIO0,
+                    tck_pin,
+                    tms_pin,
+                    tdi_pin,
+                    tdo_pin,
+                    Some(trst_pin),
+                    Some(srst_pin),
+                    &mut resets,
+                )
+            };
             initialize_usb(
                 jtagio,
                 usb_allocator,

--- a/rust-dap-rp2040/Cargo.lock
+++ b/rust-dap-rp2040/Cargo.lock
@@ -51,6 +51,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +214,12 @@ checksum = "17186ad64927d5ac8f02c1e77ccefa08ccd9eaa314d5a4772278aa204a22f7e7"
 dependencies = [
  "gcd",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "gcd"
@@ -367,6 +385,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +479,7 @@ name = "rust-dap"
 version = "0.2.0"
 dependencies = [
  "bitflags",
+ "bitvec",
  "embedded-hal",
  "heapless",
  "nb 0.1.3",
@@ -566,6 +591,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "thiserror"
 version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,4 +664,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]

--- a/rust-dap-rp2040/Cargo.lock
+++ b/rust-dap-rp2040/Cargo.lock
@@ -491,6 +491,7 @@ dependencies = [
 name = "rust-dap-rp2040"
 version = "0.2.0"
 dependencies = [
+ "bitvec",
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-rtic",

--- a/rust-dap-rp2040/Cargo.toml
+++ b/rust-dap-rp2040/Cargo.toml
@@ -31,3 +31,4 @@ heapless = "0.7"
 embedded-hal = { version = "0.2", features = ["unproven"] }
 fugit = "0.3"
 defmt = { version = "0.3", optional = true }
+bitvec = { version = "1.0.1", default-features = false }

--- a/rust-dap-rp2040/src/pio/jtag.rs
+++ b/rust-dap-rp2040/src/pio/jtag.rs
@@ -1,7 +1,4 @@
-// original author(this code is based on swd.rs):
-//      Copyright 2022 Ein Terakawa
-// jtag part author:
-//      Copyright 2023 Toshifumi Nishinaga
+// Copyright 2023 Toshifumi Nishinaga
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/rust-dap-rp2040/src/pio/jtag.rs
+++ b/rust-dap-rp2040/src/pio/jtag.rs
@@ -1,0 +1,851 @@
+// original author(this code is based on swd.rs):
+//      Copyright 2022 Ein Terakawa
+// jtag part author:
+//      Copyright 2023 Toshifumi Nishinaga
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use cortex_m::asm;
+use hal::{
+    gpio::{bank0, PinId},
+    pac::{self, PIO0},
+    pio::PIOExt,
+};
+use rp2040_hal as hal;
+use rust_dap::*;
+pub mod pio0 {
+    use crate::pio::hal::{self, gpio::FunctionPio0};
+    pub type Pin<P> = hal::gpio::Pin<P, FunctionPio0>;
+}
+use bitvec::prelude::*;
+
+use super::{swj_pins_program, DEFAULT_CORE_CLOCK, DEFAULT_PIO_DIVISOR};
+
+// TCKを1周期実行するのに必要なサイクル数
+// number of cycles required to send 1 TCK clock
+#[cfg(feature = "set_clock")]
+const NUM_OF_CYCLE_PER_TCK_CLOCK: usize = 8;
+#[cfg(feature = "set_clock")]
+const DEFAULT_SWJ_CLOCK_HZ: u32 =
+    ((125000000 / NUM_OF_CYCLE_PER_TCK_CLOCK) as f32 / DEFAULT_PIO_DIVISOR) as u32;
+
+const MAX_IR_LENGTH: usize = 128;
+
+struct JtagPioContext {
+    pio: hal::pio::PIO<PIO0>,
+    running_sm: hal::pio::StateMachine<hal::pio::PIO0SM0, hal::pio::Running>,
+    rx_fifo: hal::pio::Rx<hal::pio::PIO0SM0>,
+    tx_fifo: hal::pio::Tx<hal::pio::PIO0SM0>,
+}
+pub struct JtagIoSet<Tck, Tms, Tdi, Tdo, Trst, Srst> {
+    tck_pin_id: u8,
+    tms_pin_id: u8,
+    tdi_pin_id: u8,
+    tdo_pin_id: u8,
+    trst_pin_id: Option<u8>,
+    srst_pin_id: Option<u8>,
+    context: Option<JtagPioContext>,
+    divisor: f32,
+    _pins: core::marker::PhantomData<(Tck, Tms, Tdi, Tdo, Trst, Srst)>,
+}
+
+fn jtag_pin_set() -> pio::Program<{ pio::RP2040_MAX_PROGRAM_SIZE }> {
+    type Assembler = pio::Assembler<{ pio::RP2040_MAX_PROGRAM_SIZE }>;
+    let mut a = Assembler::new();
+    let mut wrap_target = a.label();
+    let mut wrap_source = a.label();
+
+    a.bind(&mut wrap_target);
+    // load pin out
+    a.pull(false, true);
+    a.out(pio::OutDestination::PINS, 32);
+    // load pindirs
+    a.pull(false, true);
+    a.out(pio::OutDestination::PINDIRS, 32);
+    // return ack(0xFFFFFFFF)
+    a.mov(
+        pio::MovDestination::ISR,
+        pio::MovOperation::Invert,
+        pio::MovSource::NULL,
+    );
+    a.push(false, true);
+    a.bind(&mut wrap_source);
+
+    let program = a.assemble_with_wrap(wrap_source, wrap_target);
+    program
+}
+
+fn jtag_program() -> pio::Program<{ pio::RP2040_MAX_PROGRAM_SIZE }> {
+    type Assembler = pio::Assembler<{ pio::RP2040_MAX_PROGRAM_SIZE }>;
+    let mut a = Assembler::new_with_side_set(pio::SideSet::new(true, 1, false));
+    let mut wrap_target = a.label();
+    let mut wrap_source = a.label();
+    let mut tdi_shift_start = a.label();
+    let mut tdi_shift_init = a.label();
+    let mut tdi_shift_end = a.label();
+    let mut last_one_bit = a.label();
+
+    // data format
+    // [
+    //      bit length(31bit) | tms bit(1bit)
+    //      data bits(n-bit)
+    // ]
+
+    // WARNING: bit length must be greater than 0
+
+    a.bind(&mut wrap_target);
+
+    // set tms = 0
+    a.set(pio::SetDestination::PINS, 0);
+
+    // pull size(31bit) | tms_value(1bit)
+    a.pull(false, true);
+    // out tms_value
+    a.out(pio::OutDestination::Y, 1);
+    // out bit length to X
+    a.out(pio::OutDestination::X, 31);
+
+    // pull first 32bit
+    a.pull(false, true);
+
+    a.jmp_with_side_set(pio::JmpCondition::Always, &mut tdi_shift_init, 1);
+
+    // do {
+    {
+        a.bind(&mut tdi_shift_start);
+
+        // falling edge
+        // LowのときにOutして、HighのときにInする
+
+        // falling part(4 clock)
+        // set 1 bit from OSR
+        // MEMO: outとnopは一緒にしても大丈夫？
+        // a.out(pio::OutDestination::PINS, 1);
+        // a.nop_with_delay_and_side_set(2, 0);
+        a.out_with_delay_and_side_set(pio::OutDestination::PINS, 1, 3, 0);
+
+        // rising part(4 instruction)
+        a.in_with_side_set(pio::InSource::PINS, 1, 1);
+        a.bind(&mut tdi_shift_init);
+        // push if (32 <= bit count)
+        a.push(true, true);
+        // pull if (32 <= bit count)
+        a.pull(true, true);
+        // jmp
+        a.jmp(pio::JmpCondition::XDecNonZero, &mut tdi_shift_start);
+
+        a.bind(&mut tdi_shift_end);
+    } // } while(0 < x--);
+
+    // send last 1 bit
+    // tms == 0 now
+    // if tms bit(Y) != 0
+    a.jmp(pio::JmpCondition::YIsZero, &mut last_one_bit);
+    {
+        // set tms high
+        a.set(pio::SetDestination::PINS, 1);
+    }
+
+    a.bind(&mut last_one_bit);
+
+    // falling part(4 cycle)
+    // set 1 bit from OSR
+    a.out(pio::OutDestination::PINS, 1);
+    a.nop_with_delay_and_side_set(3, 0);
+    // rising part(4 cycle)
+    // input TDO
+    a.in_with_delay_and_side_set(pio::InSource::PINS, 1, 2, 1);
+    // send last bit
+    a.push(false, true);
+
+    a.bind(&mut wrap_source);
+
+    let program = a.assemble_with_wrap(wrap_source, wrap_target);
+    program
+}
+
+impl<Tck, Tms, Tdi, Tdo, Trst, Srst>
+    JtagIoSet<
+        pio0::Pin<Tck>,
+        pio0::Pin<Tms>,
+        pio0::Pin<Tdi>,
+        pio0::Pin<Tdo>,
+        pio0::Pin<Trst>,
+        pio0::Pin<Srst>,
+    >
+where
+    Tck: PinId + bank0::BankPinId,
+    Tms: PinId + bank0::BankPinId,
+    Tdi: PinId + bank0::BankPinId,
+    Tdo: PinId + bank0::BankPinId,
+    Trst: PinId + bank0::BankPinId,
+    Srst: PinId + bank0::BankPinId,
+{
+    pub fn new(
+        pio0: pac::PIO0,
+        _tck: pio0::Pin<Tck>,
+        _tms: pio0::Pin<Tms>,
+        _tdi: pio0::Pin<Tdi>,
+        _tdo: pio0::Pin<Tdo>,
+        trst: Option<pio0::Pin<Trst>>,
+        srst: Option<pio0::Pin<Srst>>,
+        resets: &mut pac::RESETS,
+    ) -> Self {
+        let tck_pin_id = Tck::DYN.num;
+        let tms_pin_id = Tms::DYN.num;
+        let tdi_pin_id = Tdi::DYN.num;
+        let tdo_pin_id = Tdo::DYN.num;
+        let trst_pin_id = if trst.is_some() {
+            Some(Trst::DYN.num)
+        } else {
+            None
+        };
+        let srst_pin_id: Option<u8> = if srst.is_some() {
+            Some(Srst::DYN.num)
+        } else {
+            None
+        };
+
+        let program = jtag_pin_set();
+        let divisor = crate::pio::DEFAULT_PIO_DIVISOR;
+
+        // Initialize and start PIO
+        let (mut pio, sm0, _, _, _) = pio0.split(resets);
+        let installed = pio.install(&program).unwrap();
+        let (sm, rx, tx) = hal::pio::PIOBuilder::from_program(installed)
+            .set_pins(tms_pin_id, 1)
+            .side_set_pin_base(tck_pin_id)
+            .out_pins(tdi_pin_id, 1)
+            .out_shift_direction(hal::pio::ShiftDirection::Right)
+            .in_pin_base(tdo_pin_id)
+            .in_shift_direction(hal::pio::ShiftDirection::Right)
+            .clock_divisor_fixed_point(divisor as u16, (divisor * 256.0) as u8)
+            .build(sm0);
+
+        let running_sm = sm.start();
+
+        let mut jtagioset = Self {
+            tck_pin_id,
+            tms_pin_id,
+            tdi_pin_id,
+            tdo_pin_id,
+            trst_pin_id,
+            srst_pin_id,
+            context: Some(JtagPioContext {
+                pio,
+                running_sm,
+                rx_fifo: rx,
+                tx_fifo: tx,
+            }),
+            divisor: DEFAULT_PIO_DIVISOR,
+            _pins: core::marker::PhantomData,
+        };
+
+        jtagioset.disconnect_inner();
+
+        jtagioset
+    }
+}
+
+impl<Tck, Tms, Tdi, Tdo, Trst, Srst> JtagIoSet<Tck, Tms, Tdi, Tdo, Trst, Srst> {
+    // based on SwdIo
+    #[cfg(feature = "set_clock")]
+    fn set_clock(&mut self, frequency_hz: u32) {
+        // Calculate divisor.
+        let divisor = if frequency_hz > 0 {
+            ((125000000u32 / NUM_OF_CYCLE_PER_TCK_CLOCK as u32) / frequency_hz) as f32
+        } else {
+            DEFAULT_PIO_DIVISOR
+        };
+        let divisor = if divisor < 1.0f32 {
+            DEFAULT_PIO_DIVISOR
+        } else {
+            divisor
+        };
+        self.divisor = divisor;
+
+        // Stop SM, Reconstruct SM with new divisor.
+        let mut context = None;
+        core::mem::swap(&mut self.context, &mut context);
+        let context = context.unwrap();
+        let (sm0, installed) = context.running_sm.uninit(context.rx_fifo, context.tx_fifo);
+        let (sm, rx, tx) = hal::pio::PIOBuilder::from_program(installed)
+            .set_pins(self.tms_pin_id, 1)
+            .side_set_pin_base(self.tck_pin_id)
+            .out_pins(self.tdi_pin_id, 1)
+            .out_shift_direction(hal::pio::ShiftDirection::Right)
+            .in_pin_base(self.tdo_pin_id)
+            .in_shift_direction(hal::pio::ShiftDirection::Right)
+            .clock_divisor_fixed_point(divisor as u16, (divisor * 256.0) as u8)
+            .build(sm0);
+        let running_sm = sm.start();
+        let pio = context.pio;
+
+        let mut new_context = Some(JtagPioContext {
+            pio,
+            running_sm,
+            rx_fifo: rx,
+            tx_fifo: tx,
+        });
+        core::mem::swap(&mut self.context, &mut new_context);
+    }
+
+    fn get_context(&mut self) -> &mut JtagPioContext {
+        self.context.as_mut().unwrap()
+    }
+
+    fn install_swj_pins_program(&mut self) {
+        // Calculate divisor.
+        // set 0.1us = 10 MHz
+        // core frequency(MHz) / 100(MHz) = 0.1us/clock
+        let system_clock = f32::try_from((DEFAULT_CORE_CLOCK / 1_000_000) as u16).unwrap();
+        let divisor = system_clock / 10f32;
+
+        // Stop SM, Reconstruct SM with new program.
+        let mut context = None;
+        core::mem::swap(&mut self.context, &mut context);
+        let context = context.unwrap();
+        let (sm0, installed) = context.running_sm.uninit(context.rx_fifo, context.tx_fifo);
+        let mut pio = context.pio;
+        pio.uninstall(installed);
+        let installed = pio.install(&swj_pins_program()).unwrap();
+        let (sm, rx_fifo, tx_fifo) = hal::pio::PIOBuilder::from_program(installed)
+            .set_pins(0, 1)
+            .side_set_pin_base(0)
+            .out_pins(0, 32)
+            .out_shift_direction(hal::pio::ShiftDirection::Right)
+            .in_pin_base(0)
+            .in_shift_direction(hal::pio::ShiftDirection::Right)
+            .clock_divisor_fixed_point(divisor as u16, (divisor * 256.0) as u8)
+            .build(sm0);
+        let running_sm = sm.start();
+        let mut new_context = Some(JtagPioContext {
+            pio,
+            running_sm,
+            rx_fifo,
+            tx_fifo,
+        });
+        core::mem::swap(&mut self.context, &mut new_context);
+    }
+
+    fn install_jtag_pin_set_program(&mut self) {
+        // Stop SM, Reconstruct SM with new program.
+        let mut context = None;
+        core::mem::swap(&mut self.context, &mut context);
+        let context = context.unwrap();
+        let (sm0, installed) = context.running_sm.uninit(context.rx_fifo, context.tx_fifo);
+        let mut pio = context.pio;
+        pio.uninstall(installed);
+        let installed = pio.install(&jtag_pin_set()).unwrap();
+        let divisor = crate::pio::DEFAULT_PIO_DIVISOR;
+        let (sm, rx_fifo, tx_fifo) = hal::pio::PIOBuilder::from_program(installed)
+            .set_pins(0, 1)
+            .side_set_pin_base(0)
+            .out_pins(0, 32)
+            .out_shift_direction(hal::pio::ShiftDirection::Right)
+            .in_pin_base(0)
+            .in_shift_direction(hal::pio::ShiftDirection::Right)
+            .clock_divisor_fixed_point(divisor as u16, (divisor * 256.0) as u8)
+            .build(sm0);
+        let running_sm = sm.start();
+        let mut new_context = Some(JtagPioContext {
+            pio,
+            running_sm,
+            rx_fifo,
+            tx_fifo,
+        });
+        core::mem::swap(&mut self.context, &mut new_context);
+    }
+
+    fn install_jtag_program(&mut self) {
+        // Stop SM, Reconstruct SM with new program.
+        let mut context = None;
+        core::mem::swap(&mut self.context, &mut context);
+        let context = context.unwrap();
+        let (sm0, installed) = context.running_sm.uninit(context.rx_fifo, context.tx_fifo);
+        let mut pio = context.pio;
+        pio.uninstall(installed);
+        let installed = pio.install(&jtag_program()).unwrap();
+        let divisor = self.divisor;
+        let (sm, rx_fifo, tx_fifo) = hal::pio::PIOBuilder::from_program(installed)
+            .set_pins(self.tms_pin_id, 1)
+            .side_set_pin_base(self.tck_pin_id)
+            .out_pins(self.tdi_pin_id, 1)
+            .out_shift_direction(hal::pio::ShiftDirection::Right)
+            .in_pin_base(self.tdo_pin_id)
+            .in_shift_direction(hal::pio::ShiftDirection::Right)
+            .clock_divisor_fixed_point(divisor as u16, (divisor * 256.0) as u8)
+            .pull_threshold(32)
+            .push_threshold(32)
+            .build(sm0);
+        let running_sm = sm.start();
+        let mut new_context = Some(JtagPioContext {
+            pio,
+            running_sm,
+            rx_fifo,
+            tx_fifo,
+        });
+        core::mem::swap(&mut self.context, &mut new_context);
+    }
+
+    fn jtag_program_interface(&mut self, data: &mut BitSlice<u32>, tms: bool) {
+        if data.len() == 0 {
+            panic!("data.len() must be greater than 0");
+        }
+        let con = self.get_context();
+        // send length
+        // Pio has only post-decrementinstruction, so pre-decrement the length here
+        while !con
+            .tx_fifo
+            .write((u32::try_from(data.len()).unwrap() - 1) << 1 | if tms { 1 } else { 0 })
+        {
+            asm::nop()
+        }
+        // send bits
+        for x in data.chunks_mut(32) {
+            let bits = x.load();
+            // send bits
+            while !con.tx_fifo.write(bits) {
+                asm::nop()
+            }
+            // recv bits
+            let mut rx = loop {
+                if let Some(x) = con.rx_fifo.read() {
+                    break x;
+                } else {
+                    asm::nop()
+                }
+            };
+            if x.len() < 32 {
+                rx = rx >> (32 - x.len());
+            }
+            x.store(rx);
+        }
+    }
+
+    fn jtag_pin_set_program_interface(&mut self, pin_out: u32, pindirs: u32) {
+        let con = self.get_context();
+        while !con.tx_fifo.write(pin_out) {
+            asm::nop()
+        }
+        while !con.tx_fifo.write(pindirs) {
+            asm::nop()
+        }
+        // wait for ack
+        let ack: u32 = loop {
+            if let Some(x) = con.rx_fifo.read() {
+                break x;
+            } else {
+                asm::nop()
+            }
+        };
+        assert_eq!(ack, 0xFFFF_FFFF);
+    }
+
+    fn connect_inner(&mut self) {
+        self.install_jtag_pin_set_program();
+        // output high: trst, srst, tms, tck, tdi
+        // input: tdo
+        let pin_out = 0xFFFF_FFFF;
+        let pindirs = 1 << self.tck_pin_id
+            | 1 << self.tms_pin_id
+            | 1 << self.tdi_pin_id
+            | if let Some(id) = self.trst_pin_id {
+                1 << id
+            } else {
+                0
+            }
+            | if let Some(id) = self.srst_pin_id {
+                1 << id
+            } else {
+                0
+            };
+        self.jtag_pin_set_program_interface(pin_out, pindirs);
+
+        self.install_jtag_program();
+    }
+
+    fn disconnect_inner(&mut self) {
+        self.install_jtag_pin_set_program();
+        // all input
+        let pin_out = 0xFFFF_FFFF;
+        let pindirs = 0;
+        self.jtag_pin_set_program_interface(pin_out, pindirs);
+        // Reset clock
+        #[cfg(feature = "set_clock")]
+        self.set_clock(DEFAULT_SWJ_CLOCK_HZ);
+    }
+
+    fn write_tms(&mut self, tms: bool) {
+        let data = bits![mut u32, Lsb0; 0;1];
+        self.jtag_program_interface(data, tms);
+    }
+}
+
+impl<Tck, Tms, Tdi, Tdo, Trst, Srst> JtagIo for JtagIoSet<Tck, Tms, Tdi, Tdo, Trst, Srst> {
+    fn connect(&mut self, _config: &JtagIoConfig) {
+        // output high: trst, srst, tms, tck, tdi
+        // input: tdo
+        self.connect_inner();
+    }
+
+    fn disconnect(&mut self, _config: &JtagIoConfig) {
+        // all input
+        self.disconnect_inner();
+    }
+
+    fn swj_clock(
+        &mut self,
+        _config: &mut JtagIoConfig,
+        #[allow(unused_variables)] frequency_hz: u32,
+    ) -> core::result::Result<(), DapError> {
+        #[cfg(feature = "set_clock")]
+        self.set_clock(frequency_hz);
+        Ok(())
+    }
+
+    fn swj_sequence(&mut self, _config: &JtagIoConfig, count: usize, data: &[u8]) {
+        // https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__SWJ__Sequence.html
+
+        let data = data.view_bits::<Lsb0>();
+        let (tms_data, _) = data.split_at(count);
+        for tms in tms_data {
+            self.write_tms(*tms);
+        }
+    }
+
+    fn jtag_read_sequence(
+        &mut self,
+        _config: &JtagIoConfig,
+        clock_count: usize,
+        tms_value: bool,
+        tdi_data: u64,
+    ) -> u64 {
+        let tdi_data_lo = tdi_data as u32;
+        let tdi_data_hi = (tdi_data >> 32) as u32;
+        // we can't use view_bits on 32bit cpu
+        // https://docs.rs/bitvec/latest/src/bitvec/store.rs.html#194-195
+        let mut data = bitarr!(u32, Lsb0; 0; 64);
+        data.data.copy_from_slice(&[tdi_data_lo, tdi_data_hi]);
+        self.jtag_program_interface(&mut data.as_mut_bitslice()[..clock_count], tms_value);
+
+        data.load()
+    }
+
+    fn jtag_write_sequence(
+        &mut self,
+        config: &JtagIoConfig,
+        clock_count: usize,
+        tms_value: bool,
+        tdi_data: u64,
+    ) {
+        let _ = self.jtag_read_sequence(config, clock_count, tms_value, tdi_data);
+    }
+
+    fn jtag_idcode(
+        &mut self,
+        _config: &JtagIoConfig,
+        _index: u8,
+    ) -> core::result::Result<u32, DapError> {
+        // https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__jtag__idcode.html#details
+        Err(DapError::InvalidCommand)
+    }
+
+    fn jtag_transfer(
+        &mut self,
+        config: &JtagIoConfig,
+        dap_index: u8,
+        request: SwdRequest,
+        data: u32,
+    ) -> core::result::Result<u32, DapError> {
+        // https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__Transfer.html
+        // JTAGを使ってDAPとの送受信をやる
+
+        let instruction = if request.contains(SwdRequest::APnDP) {
+            // APACC
+            JtagInstruction::APACC as u32
+        } else {
+            // DPACC
+            JtagInstruction::DPACC as u32
+        };
+        let read = request.contains(SwdRequest::RnW);
+        let a2 = request.contains(SwdRequest::A2);
+        let a3 = request.contains(SwdRequest::A3);
+
+        // DPACCかAPACCを発行する
+        self.write_ir(config, dap_index, instruction);
+        // DRを書き込む
+        let mut dr = build_acc(data, a3, a2, true);
+        self.read_write_dr(config, dap_index, dr.as_mut_bitslice());
+        if read {
+            // TODO: OK_FALSE等の情報を返す必要がないか調べる
+            dr.shift_right(3);
+            let result: u32 = dr.load();
+            Ok(result)
+        } else {
+            Ok(0)
+        }
+    }
+
+    fn write_ir(&mut self, config: &JtagIoConfig, dap_index: u8, ir: u32) {
+        // to ShiftIR from Run-Test-Idle
+        self.write_tms(true); // SelectDR
+        self.write_tms(true); // SelectIR
+        self.write_tms(false); // CaptureIR
+        self.write_tms(false); // ShiftIR
+
+        // dap_indexの示すIRレジスタ以外はBYPASS(all 1)にする
+        // TDI -> other devices(head) -> target device -> other devices(tail) -> TDO
+        let device_count = config.device_count as usize;
+        let total_ir_bit_length: usize = (&config.ir_length[0..device_count])
+            .iter()
+            .map(|x| *x as usize)
+            .sum();
+        let target_ir_bit_length = *config.ir_length.get(dap_index as usize).unwrap() as usize;
+
+        let tail_ir_bit_length: usize = if 1 < device_count {
+            // not tested
+            config.ir_length[(device_count + 1)..]
+                .iter()
+                .map(|x| *x as usize)
+                .sum()
+        } else {
+            0
+        };
+
+        let mut ir = ir;
+        let ir_bits = bits![mut u32, Lsb0; 1;MAX_IR_LENGTH];
+        // target_ir_bits << tail | ir する
+        for i in 0..target_ir_bit_length {
+            ir_bits.set(tail_ir_bit_length + i, ir & 1 != 0);
+            ir = ir >> 1;
+        }
+
+        // write ir bits
+        self.jtag_program_interface(&mut ir_bits[0..total_ir_bit_length], true);
+
+        // to Run from Exit-IR
+        self.write_tms(true); // Update-IR
+        self.write_tms(false); // Run
+    }
+
+    fn read_write_dr(&mut self, config: &JtagIoConfig, dap_index: u8, dr: &mut BitSlice<u32>) {
+        // to ShiftIR from Run-Test-Idle
+        self.write_tms(true); // SelectDR
+        self.write_tms(false); // CaptureDR
+        self.write_tms(false); // ShiftDR
+
+        let target_position_idx = usize::from(dap_index); // zero indexed
+        let total_bits = usize::from(config.device_count) + dr.len() - 1;
+        let dr_bits = bits![mut u32, Lsb0; 1;MAX_IR_LENGTH];
+        // copy dr
+        for (i, d) in dr.iter().enumerate() {
+            dr_bits.set(target_position_idx + i, *d);
+        }
+
+        // send bits
+        self.jtag_program_interface(&mut dr_bits[0..total_bits], true);
+
+        // take out target dr bits
+        for (i, mut x) in dr.iter_mut().enumerate() {
+            x.set(dr_bits[target_position_idx + i]);
+        }
+
+        // to Run from Exit-DR
+        self.write_tms(true); // Update-DR
+        self.write_tms(false); // Run
+    }
+}
+
+impl<Tck, Tms, Tdi, Tdo, Trst, Srst> CmsisDapCommandInner
+    for JtagIoSet<Tck, Tms, Tdi, Tdo, Trst, Srst>
+{
+    fn connect(&mut self, config: &CmsisDapConfig) {
+        JtagIo::connect(self, &config.jtag);
+    }
+
+    fn disconnect(&mut self, config: &CmsisDapConfig) {
+        JtagIo::disconnect(self, &config.jtag);
+    }
+
+    fn swj_sequence(&mut self, config: &CmsisDapConfig, count: usize, data: &[u8]) {
+        JtagIo::swj_sequence(self, &config.jtag, count, data);
+    }
+
+    fn swd_sequence(
+        &mut self,
+        _config: &CmsisDapConfig,
+        _request: &[u8],
+        _response: &mut [u8],
+    ) -> core::result::Result<(usize, usize), DapError> {
+        Err(DapError::InvalidCommand)
+    }
+
+    fn jtag_sequence(
+        &mut self,
+        config: &CmsisDapConfig,
+        sequence_info: &JtagSequenceInfo,
+        tdi_data: u64,
+    ) -> core::result::Result<Option<u64>, DapError> {
+        Ok(if sequence_info.tdo_capture {
+            Some(JtagIo::jtag_read_sequence(
+                self,
+                &config.jtag,
+                sequence_info.number_of_tck_cycles,
+                sequence_info.tms_value,
+                tdi_data,
+            ))
+        } else {
+            JtagIo::jtag_write_sequence(
+                self,
+                &config.jtag,
+                sequence_info.number_of_tck_cycles,
+                sequence_info.tms_value,
+                tdi_data,
+            );
+            None
+        })
+    }
+
+    fn transfer_inner_with_retry(
+        &mut self,
+        config: &CmsisDapConfig,
+        dap_index: u8,
+        request: SwdRequest,
+        data: u32,
+    ) -> core::result::Result<u32, DapError> {
+        let mut retry_count = 0;
+        loop {
+            match JtagIo::jtag_transfer(self, &config.jtag, dap_index, request, data) {
+                Ok(value) => break Ok(value),
+                Err(DapError::SwdError(err)) => {
+                    // TODO: 動作確認
+                    if err != DAP_TRANSFER_WAIT || retry_count == config.retry_count {
+                        break Err(DapError::SwdError(err));
+                    }
+                    retry_count += 1;
+                }
+                Err(err) => break Err(err),
+            }
+        }
+    }
+
+    fn swj_pins(
+        &mut self,
+        _config: &CmsisDapConfig,
+        pin_output: u8,
+        pin_select: u8,
+        wait_us: u32,
+    ) -> core::result::Result<u8, DapError> {
+        self.install_swj_pins_program();
+
+        // clean rx fifo
+        // while !self.get_context().rx_fifo.is_empty() {
+        //     let _ = self.get_context().rx_fifo.read();
+        // }
+
+        let pin_output = SwjPins::from_bits(pin_output).unwrap();
+        let pin_select = SwjPins::from_bits(pin_select).unwrap();
+        let flags = [
+            (SwjPins::TCK_SWDCLK, self.tck_pin_id),
+            (SwjPins::TMS_SWDIO, self.tms_pin_id),
+            (SwjPins::TDI, self.tdi_pin_id),
+            (SwjPins::TDO, self.tdo_pin_id),
+            (
+                SwjPins::N_TRST,
+                if let Some(x) = self.trst_pin_id { x } else { 0 },
+            ),
+            (
+                SwjPins::N_RESET,
+                if let Some(x) = self.srst_pin_id { x } else { 0 },
+            ),
+        ];
+
+        // output
+        let pio_pin_out: u32 = flags.iter().fold(0, |out, (flag, pin_id)| {
+            out | if pin_output.contains(*flag) && pin_select.contains(*flag) {
+                1 << pin_id
+            } else {
+                0
+            }
+        });
+        self.context.as_mut().unwrap().tx_fifo.write(pio_pin_out);
+
+        // directions
+        let pio_pin_directions = flags.iter().fold(0, |dir, (flag, pin_id)| {
+            dir | (match flag {
+                // output
+                &SwjPins::TCK_SWDCLK
+                | &SwjPins::TMS_SWDIO
+                | &SwjPins::TDI
+                | &SwjPins::N_RESET
+                | &SwjPins::N_TRST => 1,
+                // input
+                &SwjPins::TDO => 0,
+                _ => 0,
+            } << pin_id)
+        });
+        self.context
+            .as_mut()
+            .unwrap()
+            .tx_fifo
+            .write(pio_pin_directions);
+
+        // wait_us
+        self.context.as_mut().unwrap().tx_fifo.write(wait_us);
+
+        // input
+        let tmp = loop {
+            if let Some(x) = self.context.as_mut().unwrap().rx_fifo.read() {
+                break x;
+            } else {
+                asm::nop();
+            };
+        };
+        // convert
+        let input = flags
+            .iter()
+            .fold(SwjPins::empty(), |input, (flag, pin_id)| {
+                input
+                    | if tmp & (1 << pin_id) != 0 {
+                        *flag
+                    } else {
+                        SwjPins::empty()
+                    }
+            });
+
+        // restore JTAG program
+        self.install_jtag_program();
+
+        Ok(input.bits())
+    }
+
+    fn swj_clock(
+        &mut self,
+        config: &mut CmsisDapConfig,
+        frequency_hz: u32,
+    ) -> core::result::Result<(), DapError> {
+        JtagIo::swj_clock(self, &mut config.jtag, frequency_hz)
+    }
+
+    fn jtag_idcode(
+        &self,
+        _config: &mut CmsisDapConfig,
+        _request: &[u8],
+        _response: &mut [u8],
+    ) -> core::result::Result<(usize, usize), DapError> {
+        unimplemented!();
+    }
+}

--- a/rust-dap-rp2040/src/pio/mod.rs
+++ b/rust-dap-rp2040/src/pio/mod.rs
@@ -1,0 +1,93 @@
+// Copyright 2022 Ein Terakawa
+// Copyright 2023 Toshifumi Nishinaga
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use pio::Program;
+use rp2040_hal as hal;
+pub mod pio0 {
+    use crate::pio::hal::{self, gpio::FunctionPio0};
+    pub type Pin<P> = hal::gpio::Pin<P, FunctionPio0>;
+}
+
+pub mod jtag;
+pub mod swd;
+
+const DEFAULT_CORE_CLOCK: u32 = 125000000;
+/// Default PIO Divisor.
+/// Generate 125/8 = 15.625[MHz] SWCLK clock.
+/// Generate 125/8 = 15.625[MHz] TCK clock(max)
+const DEFAULT_PIO_DIVISOR: f32 = 1.0f32;
+
+fn swj_pins_program() -> Program<{ pio::RP2040_MAX_PROGRAM_SIZE }> {
+    type Assembler = pio::Assembler<{ pio::RP2040_MAX_PROGRAM_SIZE }>;
+    let mut a = Assembler::new();
+    let mut delay_loop = a.label();
+    let mut wrap_target = a.label();
+    let mut wrap_source = a.label();
+
+    a.bind(&mut wrap_target);
+
+    // command data
+    // [
+    //      pin_output_values: u32,
+    //      pin_directions: u32,
+    //      wait_us:    u32
+    // ]
+
+    // load and set output value
+    a.pull(false, true);
+    a.out(pio::OutDestination::PINS, 32);
+    // load and set direction
+    a.pull(false, true);
+    a.out(pio::OutDestination::PINDIRS, 32);
+
+    // load output delay to Y
+    a.pull(false, true);
+    a.out(pio::OutDestination::Y, 32);
+
+    // wait_us
+    a.bind(&mut delay_loop);
+    // delay 9(+1) cycles * 0.1us/cycle = 1us
+    a.jmp_with_delay(pio::JmpCondition::YDecNonZero, &mut delay_loop, 9);
+
+    // check all pin status
+    a.r#in(pio::InSource::PINS, 32);
+    a.push(false, true);
+
+    a.bind(&mut wrap_source);
+
+    a.assemble_with_wrap(wrap_source, wrap_target)
+}
+
+fn all_pins_to_input_program() -> Program<{ pio::RP2040_MAX_PROGRAM_SIZE }> {
+    type Assembler = pio::Assembler<{ pio::RP2040_MAX_PROGRAM_SIZE }>;
+    let mut a = Assembler::new();
+    let mut wrap_target = a.label();
+    let mut wrap_source = a.label();
+
+    a.bind(&mut wrap_target);
+
+    a.mov(
+        pio::MovDestination::X,
+        pio::MovOperation::None,
+        pio::MovSource::NULL,
+    );
+    a.out(pio::OutDestination::PINDIRS, 32);
+
+    a.bind(&mut wrap_source);
+
+    a.assemble_with_wrap(wrap_source, wrap_target)
+}

--- a/rust-dap-rp2040/src/util.rs
+++ b/rust-dap-rp2040/src/util.rs
@@ -57,9 +57,18 @@ pub type JtagIoSet<TCK, TMS, TDI, TDO, TRST, SRST> = BitbangJtagIoSet<
 >;
 
 #[cfg(not(feature = "bitbang"))]
-use crate::pio::{pio0, SwdIoSet as PioSwdIoSet};
+use crate::pio::{jtag::JtagIoSet as PioJtagIoSet, pio0, swd::SwdIoSet as PioSwdIoSet};
 #[cfg(not(feature = "bitbang"))]
 pub type SwdIoSet<C, D, E> = PioSwdIoSet<pio0::Pin<C>, pio0::Pin<D>, pio0::Pin<E>>;
+#[cfg(not(feature = "bitbang"))]
+pub type JtagIoSet<Tck, Tms, Tdi, Tdo, Trst, Srst> = PioJtagIoSet<
+    pio0::Pin<Tck>,
+    pio0::Pin<Tms>,
+    pio0::Pin<Tdi>,
+    pio0::Pin<Tdo>,
+    pio0::Pin<Trst>,
+    pio0::Pin<Srst>,
+>;
 
 /// DelayFunc implementation which uses cortex_m::asm::delay
 #[cfg(feature = "bitbang")]

--- a/rust-dap/Cargo.lock
+++ b/rust-dap/Cargo.lock
@@ -24,6 +24,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -76,6 +88,12 @@ dependencies = [
  "nb 0.1.3",
  "void",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "hash32"
@@ -187,10 +205,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rust-dap"
 version = "0.2.0"
 dependencies = [
  "bitflags",
+ "bitvec",
  "defmt",
  "embedded-hal",
  "heapless",
@@ -258,6 +283,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "thiserror"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,3 +331,12 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]

--- a/rust-dap/Cargo.toml
+++ b/rust-dap/Cargo.toml
@@ -20,3 +20,4 @@ heapless = "0.7"
 num_enum = { version = "0.5", default-features = false }
 bitflags = "1.2"
 embedded-hal = { version = "0.2", optional = true, features = ["unproven"] }
+bitvec = { version = "1.0.1", default-features = false }

--- a/rust-dap/src/cmsis_dap.rs
+++ b/rust-dap/src/cmsis_dap.rs
@@ -21,6 +21,8 @@ use core::convert::TryInto;
 use crate::cursor::{BufferCursor, CursorError, CursorRead, CursorWrite};
 use crate::interface::*;
 use bitflags::bitflags;
+use bitvec;
+use bitvec::slice::BitSlice;
 use num_enum::{IntoPrimitive, TryFromPrimitive, TryFromPrimitiveError};
 use usb_device::class_prelude::*;
 use usb_device::Result;
@@ -196,8 +198,8 @@ pub trait JtagIo {
     ) -> core::result::Result<u32, DapError>;
 
     fn write_ir(&mut self, config: &JtagIoConfig, dap_index: u8, ir: u32);
-    fn write_dr(&mut self, config: &JtagIoConfig, dap_index: u8, dr: &[bool]);
-    fn read_write_dr(&mut self, config: &JtagIoConfig, dap_index: u8, dr: &mut [bool]);
+    fn write_dr(&mut self, config: &JtagIoConfig, dap_index: u8, dr: &BitSlice<u32>);
+    fn read_write_dr(&mut self, config: &JtagIoConfig, dap_index: u8, dr: &mut BitSlice<u32>);
 }
 
 pub const DAP_OK: u8 = 0x00;


### PR DESCRIPTION
PIOでJTAG喋る機能を作りました。

https://github.com/ciniml/rust-dap/pull/55 と https://github.com/ciniml/rust-dap/pull/56 のコードを一部流用しているので、これらのPRが取り込まれてからconflict修正してdraftを外します。

# 動作確認方法

1. `boards/rpi_pico` 以下で `cargo build --no-default-features --features jtag` を実行(set_clockを試すならそっちも追加）
2. rpi_picoに書き込む
3. GPIOをターゲットのJTAG端子に接続する
4. `openocd -f interface/cmsis-dap.cfg -c 'transport select jtag' -c 'adapter srst delay 3000'` を実行する

うまく行けば以下のようなログが出て、TAP IDが見つかるはずです。

```
~/t/r/b/rpi_pico ❯❯❯ openocd -f interface/cmsis-dap.cfg -c 'transport select jtag' -c 'cmsis_dap_usb interface 2' -c 'adapter srst delay 3000'                                                                                                                                                                                                                                                                                     ✘ 130
Open On-Chip Debugger 0.12.0
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
jtag
adapter srst delay: 3000

Info : Listening on port 6666 for tcl connections
Info : Listening on port 4444 for telnet connections
Warn : An adapter speed is not selected in the init scripts. OpenOCD will try to run the adapter at the low speed (100 kHz)
Warn : To remove this warnings and achieve reasonable communication speed with the target, set "adapter speed" or "jtag_rclk" in the init scripts.
Info : Using CMSIS-DAPv2 interface with VID:PID=0x6666:0x4444, serial=raspberry-pi-pico-jtag
Info : CMSIS-DAP: JTAG supported
Info : CMSIS-DAP: FW Version = 2.00
Info : CMSIS-DAP: Serial# = Piyo
Info : CMSIS-DAP: Interface Initialised (JTAG)
Info : SWCLK/TCK = 0 SWDIO/TMS = 0 TDI = 0 TDO = 0 nTRST = 0 nRESET = 0
Info : CMSIS-DAP: Interface ready
Info : clock speed 100 kHz
Warn : There are no enabled taps.  AUTO PROBING MIGHT NOT WORK!!
Info : cmsis-dap JTAG TLR_RESET
Info : cmsis-dap JTAG TLR_RESET
Info : JTAG tap: auto0.tap tap/device found: 0x4ba00477 (mfg: 0x23b (ARM Ltd), part: 0xba00, ver: 0x4)
Warn : AUTO auto0.tap - use "jtag newtap auto0 tap -irlen 4 -expected-id 0x4ba00477"
Warn : gdb services need one or more targets defined
^Cshutdown command invoked
```
<img width="2325" alt="Screenshot 2023-11-11 at 13 02 23" src="https://github.com/ciniml/rust-dap/assets/14229654/e88768e4-572c-47e2-b22d-4f67e9af3f01">

# レビュアにお願いしたいこと

- JTAGデバイスと通信できるか
- コードに気になるところはないか

# 未確認事項

- bitbangのとき含め、複数デバイスがJtag chainにいる場合に正しく動作するかわかっていません
    - openocdはJTAG_Sequence系しか使わないので出番がなく動作確認も難しい
- 最大速度で動かすと手持ちの機材(Pi3)は応答しないので動作確認できていません
    - 最大何MHzで動くのか、実測可能でしたらお願いしたいです
    
# 確認したいこと

- pio.rsに自分のクレジットを追加しても良いでしょうか？