### PR TITLE
起動時はRESETピンをハイインピーダンス(入力モード)のままにする

### DIFF
--- a/boards/rpi_pico/src/main.rs
+++ b/boards/rpi_pico/src/main.rs
@@ -186,38 +186,29 @@ mod app {
         #[cfg(feature = "swd")]
         let (usb_serial, usb_dap, usb_bus) = {
             // Initialize MCU reset pin.
-            let mut n_reset_pin = pins.gpio4.into_push_pull_output();
             // RESET pin of Cortex Debug 10-pin connector is negative logic
             // https://developer.arm.com/documentation/101453/0100/CoreSight-Technology/Connectors
-            n_reset_pin.set_high().ok();
+            let reset_pin = pins.gpio4.into_floating_input();
 
             let swdio;
             #[cfg(feature = "bitbang")]
             {
-                use rust_dap_rp2040::{
-                    swdio_pin::PicoSwdInputPin, swdio_pin::PicoSwdOutputPin, util::CycleDelay,
-                };
+                use rust_dap_rp2040::{swdio_pin::PicoSwdInputPin, util::CycleDelay};
                 let swclk_pin = PicoSwdInputPin::new(pins.gpio2.into_floating_input());
                 let swdio_pin = PicoSwdInputPin::new(pins.gpio3.into_floating_input());
-                let reset_pin = PicoSwdOutputPin::new(n_reset_pin);
+                let reset_pin = PicoSwdInputPin::new(reset_pin);
                 swdio = SwdIoSet::new(swclk_pin, swdio_pin, reset_pin, CycleDelay {});
             }
             #[cfg(not(feature = "bitbang"))]
             {
                 let mut swclk_pin = pins.gpio2.into_mode();
                 let mut swdio_pin = pins.gpio3.into_mode();
+                let mut reset_pin = reset_pin.into_mode();
                 swclk_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
                 swdio_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
-                let mut n_reset_pin = n_reset_pin.into_mode();
-                n_reset_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
+                reset_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
 
-                swdio = SwdIoSet::new(
-                    c.device.PIO0,
-                    swclk_pin,
-                    swdio_pin,
-                    n_reset_pin,
-                    &mut resets,
-                );
+                swdio = SwdIoSet::new(c.device.PIO0, swclk_pin, swdio_pin, reset_pin, &mut resets);
             }
             initialize_usb(
                 swdio,

--- a/boards/xiao_m0/src/main.rs
+++ b/boards/xiao_m0/src/main.rs
@@ -17,7 +17,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::v2::{OutputPin, ToggleableOutputPin};
+use embedded_hal::digital::v2::ToggleableOutputPin;
 use panic_halt as _;
 use rust_dap::bitbang::{DelayFunc, SwdIoSet};
 use rust_dap::{
@@ -96,15 +96,14 @@ fn main() -> ! {
         USB_ALLOCATOR.as_ref().unwrap()
     };
 
-    let mut n_reset_pin = pins.a0.into_push_pull_output();
     // RESET pin of Cortex Debug 10-pin connector is negative logic
     // https://developer.arm.com/documentation/101453/0100/CoreSight-Technology/Connectors
-    n_reset_pin.set_high().ok();
+    let reset_pin = pins.a0.into_floating_input();
 
     let swdio = MySwdIoSet::new(
         XiaoSwdInputPin::new(pins.a8.into_floating_input()),
         XiaoSwdInputPin::new(pins.a9.into_floating_input()),
-        XiaoSwdOutputPin::new(n_reset_pin),
+        XiaoSwdInputPin::new(reset_pin),
         CycleDelay {},
     );
 

--- a/rust-dap-rp2040/src/swdio_pin.rs
+++ b/rust-dap-rp2040/src/swdio_pin.rs
@@ -15,7 +15,7 @@
 // limitations under the License.
 
 use embedded_hal::digital::v2::{InputPin, IoPin, OutputPin, PinState};
-use hal::gpio::{Disabled, Floating, Input, Output, OutputOverride, Pin, PinId, PushPull};
+use hal::gpio::{Disabled, Floating, Input, Output, Pin, PinId, PushPull};
 use rp2040_hal as hal;
 
 /// InputPin implementation for SWD pin
@@ -56,18 +56,9 @@ where
     fn into_input_pin(self) -> Result<PicoSwdInputPin<I>, Self::Error> {
         Ok(self)
     }
-    fn into_output_pin(mut self, state: PinState) -> Result<PicoSwdOutputPin<I>, Self::Error> {
-        let output_override = if state == PinState::High {
-            OutputOverride::AlwaysHigh
-        } else {
-            OutputOverride::AlwaysLow
-        };
-        self.pin.set_output_override(output_override);
-        let mut output_pin = self.pin.into_push_pull_output();
-        output_pin.set_output_override(OutputOverride::DontInvert);
-        let mut new_pin = PicoSwdOutputPin::new(output_pin);
-        new_pin.set_state(state)?;
-        Ok(new_pin)
+    fn into_output_pin(self, state: PinState) -> Result<PicoSwdOutputPin<I>, Self::Error> {
+        let output_pin = self.pin.into_push_pull_output_in_state(state);
+        Ok(PicoSwdOutputPin::new(output_pin))
     }
 }
 
@@ -110,8 +101,8 @@ where
 {
     type Error = core::convert::Infallible;
     fn into_input_pin(self) -> Result<PicoSwdInputPin<I>, Self::Error> {
-        let new_pin = self.pin.into_floating_input();
-        Ok(PicoSwdInputPin::new(new_pin))
+        let input_pin = self.pin.into_floating_input();
+        Ok(PicoSwdInputPin::new(input_pin))
     }
     fn into_output_pin(mut self, state: PinState) -> Result<PicoSwdOutputPin<I>, Self::Error> {
         self.set_state(state)?;
@@ -137,9 +128,7 @@ where
         Ok(PicoSwdInputPin::new(input_pin))
     }
     fn into_output_pin(self, state: PinState) -> Result<PicoSwdOutputPin<I>, Self::Error> {
-        let output_pin = self.pin.into_push_pull_output();
-        let mut new_pin = PicoSwdOutputPin::new(output_pin);
-        new_pin.set_state(state)?;
-        Ok(new_pin)
+        let output_pin = self.pin.into_push_pull_output_in_state(state);
+        Ok(PicoSwdOutputPin::new(output_pin))
     }
 }

--- a/rust-dap/src/bitbang.rs
+++ b/rust-dap/src/bitbang.rs
@@ -142,7 +142,7 @@ where
     pub fn new(
         swclk: SwClkInputPin,
         swdio: SwdIoInputPin,
-        reset: ResetOutputPin,
+        reset: ResetInputPin,
         cycle_delay: DelayFn,
     ) -> Self {
         Self {
@@ -150,8 +150,8 @@ where
             swdio_out: None,
             swclk_in: Some(swclk),
             swclk_out: None,
-            reset_in: None,
-            reset_out: Some(reset),
+            reset_in: Some(reset),
+            reset_out: None,
             cycle_delay,
         }
     }
@@ -366,10 +366,12 @@ impl<Io: BitBangSwdIo> PrimitiveSwdIo for Io {
     fn connect(&mut self) {
         self.to_swclk_out(false);
         self.to_swdio_out(false);
+        self.to_reset_out(true);
     }
     fn disconnect(&mut self) {
         self.to_swclk_in();
         self.to_swdio_in();
+        self.to_reset_in();
     }
     fn enable_output(&mut self) {
         self.to_swdio_out(false);


### PR DESCRIPTION
Fix https://github.com/ciniml/rust-dap/issues/40

Connect 時に RESETピンを High にします。
懸案の50nsecほどのLowパルスが生じる問題が解決します。

board/xiao_m0 の動作確認はしていません。