### PR TITLE
Update to rp2040-hal=0.10, embedded-hal=1.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         projects: ["rust-dap", "rust-dap-rp2040", "uart-test", "boards/rpi_pico", "boards/xiao_m0", "boards/xiao_rp2040"]
     container:
-      image: rust:1.72-slim-bookworm
+      image: rust:1.75-slim-bookworm
     steps:
       - uses: actions/checkout@v2
       - name: setup

--- a/boards/rpi_pico/Cargo.lock
+++ b/boards/rpi_pico/Cargo.lock
@@ -45,6 +45,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
+name = "bitfield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,8 +81,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ec610d8f49840a5b376c69663b6369e71f4b34484b9b2eb29fb918d92516cb9"
 dependencies = [
  "bare-metal 0.2.5",
- "bitfield",
- "embedded-hal",
+ "bitfield 0.13.2",
+ "embedded-hal 0.2.7",
  "volatile-register",
 ]
 
@@ -109,7 +115,7 @@ dependencies = [
  "bare-metal 1.0.0",
  "cortex-m",
  "cortex-m-rtic-macros",
- "heapless",
+ "heapless 0.7.16",
  "rtic-core",
  "rtic-monotonic",
  "version_check",
@@ -217,6 +223,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-hal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "embedded-hal-async"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
+dependencies = [
+ "embedded-hal 1.0.0",
+]
+
+[[package]]
+name = "embedded-hal-nb"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba4268c14288c828995299e59b12babdbe170f6c6d73731af1b4648142e8605"
+dependencies = [
+ "embedded-hal 1.0.0",
+ "nb 1.1.0",
+]
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "frunk"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +323,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,9 +344,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
  "atomic-polyfill",
- "hash32",
+ "hash32 0.2.1",
  "rustc_version 0.4.0",
  "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -402,6 +458,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,9 +519,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rp-pico"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6341771e6f8e5d130b2b3cbc23435b7847761adf198af09f4b2a60407d43bd56"
+checksum = "b9342d3ac7011ac688300979e9b52a81f0add1d05feb02868cf94bfee0705b28"
 dependencies = [
  "cortex-m-rt",
  "fugit",
@@ -478,14 +540,19 @@ dependencies = [
 
 [[package]]
 name = "rp2040-hal"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff2b9ae7e6dd6720fd9f64250c9087260e50fe98b6b032ccca65be3581167ca"
+checksum = "d11e711940087f2cdff8aeae9f4b902e2014c06a00b39a1092686b81ec973d6f"
 dependencies = [
+ "bitfield 0.14.0",
  "cortex-m",
  "critical-section",
  "embedded-dma",
- "embedded-hal",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "embedded-hal-nb",
+ "embedded-io",
  "frunk",
  "fugit",
  "itertools",
@@ -514,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "rp2040-pac"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d9d8375815f543f54835d01160d4e47f9e2cae75f17ff8f1ec19ce1da96e4c"
+checksum = "83cbcd3f7a0ca7bbe61dc4eb7e202842bee4e27b769a7bf3a4a72fa399d6e404"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -550,13 +617,13 @@ dependencies = [
 
 [[package]]
 name = "rust-dap"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitflags",
  "bitvec",
  "defmt",
- "embedded-hal",
- "heapless",
+ "embedded-hal 1.0.0",
+ "heapless 0.7.16",
  "nb 0.1.3",
  "num_enum",
  "usb-device",
@@ -564,16 +631,16 @@ dependencies = [
 
 [[package]]
 name = "rust-dap-raspberrypi-pico"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-rtic",
  "defmt",
  "defmt-rtt",
- "embedded-hal",
- "heapless",
- "nb 0.1.3",
+ "embedded-hal 1.0.0",
+ "embedded-hal-nb",
+ "heapless 0.7.16",
  "panic-halt",
  "panic-probe",
  "rp-pico",
@@ -585,16 +652,16 @@ dependencies = [
 
 [[package]]
 name = "rust-dap-rp2040"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bitvec",
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-rtic",
  "defmt",
- "embedded-hal",
+ "embedded-hal 1.0.0",
  "fugit",
- "heapless",
+ "heapless 0.7.16",
  "nb 0.1.3",
  "panic-halt",
  "pio",
@@ -721,18 +788,23 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "usb-device"
-version = "0.2.9"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
+checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
+dependencies = [
+ "heapless 0.8.0",
+ "portable-atomic",
+]
 
 [[package]]
 name = "usbd-serial"
-version = "0.1.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db75519b86287f12dcf0d171c7cf4ecc839149fe9f3b720ac4cfce52959e1dfe"
+checksum = "065e4eaf93db81d5adac82d9cef8f8da314cb640fa7f89534b972383f1cf80fc"
 dependencies = [
- "embedded-hal",
- "nb 0.1.3",
+ "embedded-hal 0.2.7",
+ "embedded-io",
+ "nb 1.1.0",
  "usb-device",
 ]
 

--- a/boards/rpi_pico/Cargo.lock
+++ b/boards/rpi_pico/Cargo.lock
@@ -217,6 +217,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "frunk"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28aef0f9aa070bce60767c12ba9cb41efeaf1a2bc6427f87b7d83f11239a16d7"
+dependencies = [
+ "frunk_core",
+ "frunk_derives",
+]
+
+[[package]]
+name = "frunk_core"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "476eeaa382e3462b84da5d6ba3da97b5786823c2d0d3a0d04ef088d073da225c"
+
+[[package]]
+name = "frunk_derives"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b4095fc99e1d858e5b8c7125d2638372ec85aa0fe6c807105cf10b0265ca6c"
+dependencies = [
+ "frunk_proc_macro_helpers",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
+name = "frunk_proc_macro_helpers"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1952b802269f2db12ab7c0bd328d0ae8feaabf19f352a7b0af7bb0c5693abfce"
+dependencies = [
+ "frunk_core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
 name = "fugit"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,11 +457,10 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rp-pico"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aab28f6f4e19cec2d61b64cdd685e69794b81c579fd3b765579c46018fe616d0"
+checksum = "6341771e6f8e5d130b2b3cbc23435b7847761adf198af09f4b2a60407d43bd56"
 dependencies = [
- "cortex-m",
  "cortex-m-rt",
  "fugit",
  "rp2040-hal",
@@ -440,14 +478,15 @@ dependencies = [
 
 [[package]]
 name = "rp2040-hal"
-version = "0.8.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1369bb84862d7f69391a96606b2f29a00bfce7f29a749e23d5f01fc3f607ada0"
+checksum = "1ff2b9ae7e6dd6720fd9f64250c9087260e50fe98b6b032ccca65be3581167ca"
 dependencies = [
  "cortex-m",
  "critical-section",
  "embedded-dma",
  "embedded-hal",
+ "frunk",
  "fugit",
  "itertools",
  "nb 1.1.0",
@@ -475,12 +514,13 @@ dependencies = [
 
 [[package]]
 name = "rp2040-pac"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9192cafbb40d717c9e0ddf767aaf9c69fee1b4e48d22ed853b57b11f6d9f3d7e"
+checksum = "12d9d8375815f543f54835d01160d4e47f9e2cae75f17ff8f1ec19ce1da96e4c"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
+ "critical-section",
  "vcell",
 ]
 
@@ -524,7 +564,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dap-raspberrypi-pico"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -545,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dap-rp2040"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitvec",
  "cortex-m",

--- a/boards/rpi_pico/Cargo.toml
+++ b/boards/rpi_pico/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-dap-raspberrypi-pico"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Kenta IDA <fuga@fugafuga.org>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -32,24 +32,24 @@ swj = []
 ram-exec = ["rust-dap-rp2040/ram-exec"] # Execute-in-SRAM support
 
 [dependencies.rp-pico]
-version = "0.8"
+version = "0.9"
 # Below is to take out "boot2" from the set of features.
 default-features = false
 features = ["rt", "critical-section-impl"]
 
 [dependencies]
-rust-dap = { path = "../../rust-dap", features = ["unproven"] }
+rust-dap = { path = "../../rust-dap" }
 rust-dap-rp2040 = { path = "../../rust-dap-rp2040" }
 panic-halt = "0.2"
 cortex-m = { version = "0.7" }
 cortex-m-rt = "0.7"
 cortex-m-rtic = "1.0"
 
-usb-device = { version = "0.2", features = ["control-buffer-256"] }
-usbd-serial = "0.1"
-nb = "0.1"
+usb-device = { version = "0.3", features = ["control-buffer-256"] }
+usbd-serial = "0.2"
 heapless = "0.7"
-embedded-hal = { version = "0.2", features = ["unproven"] }
+embedded-hal = "1"
+embedded-hal-nb = "1"
 defmt = { version = "0.3", optional = true }
 defmt-rtt = { version = "0.4", optional = true }
 panic-probe = { version = "0.3", features = ["print-defmt"], optional = true }

--- a/boards/rpi_pico/Cargo.toml
+++ b/boards/rpi_pico/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-dap-raspberrypi-pico"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Kenta IDA <fuga@fugafuga.org>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -32,7 +32,7 @@ swj = []
 ram-exec = ["rust-dap-rp2040/ram-exec"] # Execute-in-SRAM support
 
 [dependencies.rp-pico]
-version = "0.7"
+version = "0.8"
 # Below is to take out "boot2" from the set of features.
 default-features = false
 features = ["rt", "critical-section-impl"]

--- a/boards/rpi_pico/src/main.rs
+++ b/boards/rpi_pico/src/main.rs
@@ -36,8 +36,8 @@ mod app {
     use usb_device::prelude::*;
     use usbd_serial::SerialPort;
 
-    use embedded_hal::digital::v2::{OutputPin, ToggleableOutputPin};
-    use embedded_hal::serial::{Read, Write};
+    use embedded_hal::digital::{OutputPin, StatefulOutputPin};
+    use embedded_hal_nb::serial::{Read, Write};
 
     use rust_dap_rp2040::line_coding::*;
     use rust_dap_rp2040::util::{

--- a/boards/rpi_pico/src/main.rs
+++ b/boards/rpi_pico/src/main.rs
@@ -25,7 +25,7 @@ mod app {
     use {defmt_rtt as _, panic_probe as _};
 
     use hal::clocks::Clock;
-    use hal::gpio::{Output, Pin, PushPull};
+    use hal::gpio::{FunctionSioOutput, FunctionUart, Pin, PullDown};
     use hal::pac;
     use rp_pico::hal;
 
@@ -95,8 +95,8 @@ mod app {
     const UART_TX_QUEUE_SIZE: usize = 128;
     // UART Shared context
     type UartPins = (
-        hal::gpio::Pin<GpioUartTx, hal::gpio::Function<hal::gpio::Uart>>,
-        hal::gpio::Pin<GpioUartRx, hal::gpio::Function<hal::gpio::Uart>>,
+        Pin<GpioUartTx, FunctionUart, PullDown>,
+        Pin<GpioUartRx, FunctionUart, PullDown>,
     );
     type Uart = hal::uart::UartPeripheral<hal::uart::Enabled, pac::UART0, UartPins>;
     pub struct UartReader(hal::uart::Reader<pac::UART0, UartPins>);
@@ -122,11 +122,11 @@ mod app {
         uart_rx_producer: heapless::spsc::Producer<'static, u8, UART_RX_QUEUE_SIZE>,
         usb_bus: UsbDevice<'static, UsbBus>,
         usb_dap: CmsisDap<'static, UsbBus, IoSet, 64>,
-        usb_led: Pin<GpioUsbLed, Output<PushPull>>,
-        idle_led: Pin<GpioIdleLed, Output<PushPull>>,
-        debug_out: Pin<GpioDebugOut, Output<PushPull>>,
-        debug_irq_out: Pin<GpioDebugIrqOut, Output<PushPull>>,
-        debug_usb_irq_out: Pin<GpioDebugUsbIrqOut, Output<PushPull>>,
+        usb_led: Pin<GpioUsbLed, FunctionSioOutput, PullDown>,
+        idle_led: Pin<GpioIdleLed, FunctionSioOutput, PullDown>,
+        debug_out: Pin<GpioDebugOut, FunctionSioOutput, PullDown>,
+        debug_irq_out: Pin<GpioDebugIrqOut, FunctionSioOutput, PullDown>,
+        debug_usb_irq_out: Pin<GpioDebugUsbIrqOut, FunctionSioOutput, PullDown>,
     }
 
     #[init(local = [
@@ -158,8 +158,8 @@ mod app {
         .unwrap();
 
         let uart_pins = (
-            pins.gpio0.into_mode::<hal::gpio::FunctionUart>(), // TxD
-            pins.gpio1.into_mode::<hal::gpio::FunctionUart>(), // RxD
+            pins.gpio0.reconfigure(), // TxD
+            pins.gpio1.reconfigure(), // RxD
         );
         let uart_config = UartConfigAndClock {
             config: UartConfig::from(hal::uart::UartConfig::default()),
@@ -201,9 +201,9 @@ mod app {
             }
             #[cfg(not(feature = "bitbang"))]
             {
-                let mut swclk_pin = pins.gpio2.into_mode();
-                let mut swdio_pin = pins.gpio3.into_mode();
-                let mut reset_pin = reset_pin.into_mode();
+                let mut swclk_pin = pins.gpio2.reconfigure();
+                let mut swdio_pin = pins.gpio3.reconfigure();
+                let mut reset_pin = reset_pin.reconfigure();
                 swclk_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
                 swdio_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
                 reset_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
@@ -243,12 +243,12 @@ mod app {
             #[cfg(not(feature = "bitbang"))]
             {
                 // PIO
-                let mut tck_pin = pins.gpio2.into_mode();
-                let mut tms_pin = pins.gpio3.into_mode();
-                let mut tdo_pin = pins.gpio5.into_mode();
-                let mut tdi_pin = pins.gpio6.into_mode();
-                let mut trst_pin = pins.gpio7.into_mode();
-                let mut srst_pin = pins.gpio4.into_mode();
+                let mut tck_pin = pins.gpio2.reconfigure();
+                let mut tms_pin = pins.gpio3.reconfigure();
+                let mut tdo_pin = pins.gpio5.reconfigure();
+                let mut tdi_pin = pins.gpio6.reconfigure();
+                let mut trst_pin = pins.gpio7.reconfigure();
+                let mut srst_pin = pins.gpio4.reconfigure();
                 tck_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
                 tms_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
                 tdo_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);

--- a/boards/xiao_m0/Cargo.lock
+++ b/boards/xiao_m0/Cargo.lock
@@ -3,24 +3,15 @@
 version = 3
 
 [[package]]
-name = "aligned"
-version = "0.3.4"
+name = "aes"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19796bd8d477f1a9d4ac2465b464a8b1359474f06a96bb3cda650b4fca309bf"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
- "as-slice",
-]
-
-[[package]]
-name = "as-slice"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45403b49e3954a4b8428a0ac21a4b7afadccf92bfd96273f1a58cd4812496ae0"
-dependencies = [
- "generic-array 0.12.4",
- "generic-array 0.13.3",
- "generic-array 0.14.4",
- "stable_deref_trait",
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -29,26 +20,33 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30302dda7a66f8c55932ebf208f7def840743ff64d495e9ceffcd97c18f11d39"
 dependencies = [
- "cortex-m 0.7.2",
+ "cortex-m",
 ]
 
 [[package]]
 name = "atsamd-hal"
-version = "0.13.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb5dce6169ab96f922232f87f2f301429bd947ff417cd6695b4ad1e1c5b83a01"
+checksum = "84fba26d12e032c93fb0de8c0e0ff34fafea35192f61cd0fc247838d78cda22e"
 dependencies = [
+ "aes",
+ "atsamd-hal-macros",
  "atsamd21g",
  "bitfield",
  "bitflags",
- "cortex-m 0.6.7",
- "embedded-hal",
+ "cipher",
+ "cortex-m",
+ "embedded-hal 0.2.6",
+ "embedded-hal 1.0.0",
+ "embedded-hal-nb",
+ "embedded-io",
+ "fugit",
  "modular-bitfield",
- "nb 0.1.3",
+ "nb 1.0.0",
  "num-traits",
+ "opaque-debug",
  "paste",
  "rand_core",
- "replace_with",
  "seq-macro",
  "typenum",
  "usb-device",
@@ -57,14 +55,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "atsamd21g"
-version = "0.10.0"
+name = "atsamd-hal-macros"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6256c8fd4ea5739c8582885eaf0800e3d2f3cb484e66e0a1a0892dbbdc4e4a9e"
+checksum = "b27ccb060a908ff8a40acde574902a6bd283d3420dd4ffcdb6a327225f55e098"
 dependencies = [
- "bare-metal",
- "cortex-m 0.6.7",
+ "litrs",
+ "phf",
+ "phf_codegen",
+ "serde",
+ "serde_yaml",
+]
+
+[[package]]
+name = "atsamd21g"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc7fa02c53f5039898dc16880423b13e5f27238466f3999790ff79330c8c00d"
+dependencies = [
+ "cortex-m",
  "cortex-m-rt",
+ "critical-section",
  "vcell",
 ]
 
@@ -96,56 +107,85 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
-name = "cortex-m"
-version = "0.6.7"
+name = "cfg-if"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9075300b07c6a56263b9b582c214d0ff037b00d45ec9fde1cc711490c56f1bb9"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "aligned",
- "bare-metal",
- "bitfield",
- "cortex-m 0.7.2",
- "volatile-register",
+ "generic-array",
 ]
 
 [[package]]
 name = "cortex-m"
-version = "0.7.2"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643a210c1bdc23d0db511e2a576082f4ff4dcae9d0c37f50b431b8f8439d6d6b"
+checksum = "8ec610d8f49840a5b376c69663b6369e71f4b34484b9b2eb29fb918d92516cb9"
 dependencies = [
  "bare-metal",
  "bitfield",
- "embedded-hal",
+ "critical-section",
+ "embedded-hal 0.2.6",
  "volatile-register",
 ]
 
 [[package]]
 name = "cortex-m-rt"
-version = "0.6.15"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "454f278bf469e2de0a4d22ea019d169d8944f86957c8207a39e3f66c32be2fc6"
+checksum = "801d4dec46b34c299ccf6b036717ae0fce602faa4f4fe816d9013b9a7c9f5ba6"
 dependencies = [
  "cortex-m-rt-macros",
- "r0",
 ]
 
 [[package]]
 name = "cortex-m-rt-macros"
-version = "0.6.15"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3aa52243e26f5922fa522b0814019e0c98fc567e2756d715dce7ad7a81f49"
+checksum = "e37549a379a9e0e6e576fd208ee60394ccb8be963889eebba3ffe0980364f472"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.106",
 ]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "derivative"
@@ -155,7 +195,7 @@ checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -169,22 +209,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.12.4"
+name = "embedded-hal"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "embedded-hal-nb"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba4268c14288c828995299e59b12babdbe170f6c6d73731af1b4648142e8605"
 dependencies = [
- "typenum",
+ "embedded-hal 1.0.0",
+ "nb 1.0.0",
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.13.3"
+name = "embedded-io"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f797e67af32588215eaaab8327027ee8e71b9dd0b2b26996aedf20c030fce309"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fugit"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17186ad64927d5ac8f02c1e77ccefa08ccd9eaa314d5a4772278aa204a22f7e7"
 dependencies = [
- "typenum",
+ "gcd",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "gcd"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
 name = "generic-array"
@@ -206,14 +277,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
 name = "heapless"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7ee8a997d259962217f40279f34201fdf06e669bafa69d7c1f4c7ff1893b5f6"
 dependencies = [
  "atomic-polyfill",
- "hash32",
+ "hash32 0.2.1",
  "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32 0.3.1",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "libc"
+version = "0.2.175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "litrs"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
+dependencies = [
+ "proc-macro2",
 ]
 
 [[package]]
@@ -234,7 +361,7 @@ checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.72",
 ]
 
 [[package]]
@@ -279,8 +406,14 @@ checksum = "1c0fd9eba1d5db0994a239e09c1be402d35622277e35468ba891aa5e3188ce7e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.72",
 ]
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "panic-halt"
@@ -290,67 +423,113 @@ checksum = "de96540e0ebde571dc55c73d60ef407c653844e6f9a1e2fdbd40c07b9252d812"
 
 [[package]]
 name = "paste"
-version = "1.0.5"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.27"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8caf72986c1a598726adc988bb5984792ef84f5ee5aa50209145ee8077038"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.9"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "r0"
-version = "0.2.2"
+name = "radium"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a38df5b15c8d5c7e8654189744d8e396bddc18ad48041a500ce52d6948941f"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_core",
+]
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-
-[[package]]
-name = "replace_with"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a8614ee435691de62bcffcf4a66d91b3594bf1428a5722e79103249a095690"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rust-dap"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitflags",
- "embedded-hal",
- "heapless",
- "nb 0.1.3",
+ "bitvec",
+ "embedded-hal 1.0.0",
+ "heapless 0.7.1",
  "num_enum",
  "usb-device",
 ]
 
 [[package]]
 name = "rust-dap-xiao"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
- "cortex-m 0.6.7",
+ "cortex-m",
  "cortex-m-rt",
- "embedded-hal",
- "heapless",
- "nb 0.1.3",
+ "embedded-hal 1.0.0",
+ "heapless 0.7.1",
  "panic-halt",
  "rust-dap",
  "usb-device",
@@ -366,6 +545,12 @@ checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "semver"
@@ -384,9 +569,58 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "seq-macro"
-version = "0.2.2"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9f47faea3cad316faa914d013d24f471cd90bfca1a0c70f05a3f42c6441e99"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
+name = "serde"
+version = "1.0.221"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "341877e04a22458705eb4e131a1508483c877dca2792b3781d4e5d8a6019ec43"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.221"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c459bc0a14c840cb403fc14b148620de1e0778c96ecd6e0c8c3cacb6d8d00fe"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.221"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6185cf75117e20e62b1ff867b9518577271e58abe0037c40bb4794969355ab0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "stable_deref_trait"
@@ -412,10 +646,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "typenum"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-xid"
@@ -424,19 +681,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
-name = "usb-device"
-version = "0.2.8"
+name = "unsafe-libyaml"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6be90410d4772074ea49525e2e753b65920b94b57eee21a6ef7b6a6fe6296245"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "usb-device"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
+dependencies = [
+ "heapless 0.8.0",
+ "portable-atomic",
+]
 
 [[package]]
 name = "usbd-serial"
-version = "0.1.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db75519b86287f12dcf0d171c7cf4ecc839149fe9f3b720ac4cfce52959e1dfe"
+checksum = "065e4eaf93db81d5adac82d9cef8f8da314cb640fa7f89534b972383f1cf80fc"
 dependencies = [
- "embedded-hal",
- "nb 0.1.3",
+ "embedded-hal 0.2.6",
+ "embedded-io",
+ "nb 1.0.0",
  "usb-device",
 ]
 
@@ -468,10 +736,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "xiao_m0"
-version = "0.11.0"
+name = "wyz"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b8a15c3048887b8e0bcfcfe471a36162a42897b1113da6307e7b2547ac13e8"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
+name = "xiao_m0"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79c0b0e12f25458aee8004c8f6a3a5f2a6e670cace39950191f8478ae3ee41a8"
 dependencies = [
  "atsamd-hal",
  "cortex-m-rt",

--- a/boards/xiao_m0/Cargo.toml
+++ b/boards/xiao_m0/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-dap-xiao"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Kenta IDA <fuga@fugafuga.org>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -8,14 +8,13 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rust-dap = { path = "../../rust-dap", features = ["bitbang", "unproven"] }
-xiao_m0 = { version = "0.11", features = ["usb", "unproven"]}
+rust-dap = { path = "../../rust-dap", features = ["bitbang"] }
+xiao_m0 = { version = "0.13", features = ["usb"] }
 panic-halt = "0.2"
-cortex-m = "0.6"
-cortex-m-rt = "0.6"
+cortex-m = { version = "0.7", features = ["critical-section-single-core"] }
+cortex-m-rt = "0.7"
 
-usb-device = { version = "0.2", features = ["control-buffer-256"]}
-usbd-serial = "0.1"
-nb = "0.1"
+usb-device = { version = "0.3", features = ["control-buffer-256"] }
+usbd-serial = "0.2"
 heapless = "0.7"
-embedded-hal = { version = "0.2.6", features = ["unproven"] }
+embedded-hal = "1"

--- a/boards/xiao_m0/src/main.rs
+++ b/boards/xiao_m0/src/main.rs
@@ -17,7 +17,7 @@
 #![no_std]
 #![no_main]
 
-use embedded_hal::digital::v2::ToggleableOutputPin;
+use embedded_hal::digital::StatefulOutputPin;
 use panic_halt as _;
 use rust_dap::bitbang::{DelayFunc, SwdIoSet};
 use rust_dap::{
@@ -26,7 +26,7 @@ use rust_dap::{
 
 use bsp::{entry, hal, pac};
 use hal::clock::GenericClockController;
-use hal::gpio::v2::{Output, Pin, PushPull};
+use hal::gpio::{Output, Pin, PushPull};
 use pac::{interrupt, CorePeripherals, Peripherals};
 use xiao_m0 as bsp;
 
@@ -43,7 +43,7 @@ mod swdio_pin;
 use swdio_pin::*;
 
 // Import pin types.
-use hal::gpio::v2::{PA02, PA05, PA07, PA18};
+use hal::gpio::{PA02, PA05, PA07, PA18};
 
 type SwdIoPin = PA05; // D9
 type SwClkPin = PA07; // D8
@@ -112,14 +112,17 @@ fn main() -> ! {
         USB_DAP = Some(CmsisDap::new(bus_allocator, swdio, DapCapabilities::SWD));
         USB_BUS = Some(
             UsbDeviceBuilder::new(bus_allocator, UsbVidPid(0x6666, 0x4444))
-                .manufacturer("fugafuga.org")
-                .product("CMSIS-DAP")
-                .serial_number("test")
+                .strings(&[StringDescriptors::default()
+                    .manufacturer("fugafuga.org")
+                    .product("CMSIS-DAP")
+                    .serial_number("test")])
+                .unwrap()
                 .device_class(USB_CLASS_MISCELLANEOUS)
                 .device_class(USB_SUBCLASS_COMMON)
                 .device_protocol(USB_PROTOCOL_IAD)
                 .composite_with_iads()
                 .max_packet_size_0(64)
+                .unwrap()
                 .build(),
         );
         LED = Some(pins.led1.into_push_pull_output());

--- a/boards/xiao_m0/src/swdio_pin.rs
+++ b/boards/xiao_m0/src/swdio_pin.rs
@@ -1,5 +1,6 @@
-use embedded_hal::digital::v2::{InputPin, IoPin, OutputPin, PinState};
-use xiao_m0::hal::gpio::v2::pin::{Disabled, Floating, Input, Output, Pin, PinId, PushPull};
+use embedded_hal::digital::{ErrorType, InputPin, OutputPin, PinState};
+use rust_dap::bitbang::IoPin;
+use xiao_m0::hal::gpio::pin::{Disabled, Floating, Input, Output, Pin, PinId, PushPull};
 
 pub struct XiaoSwdInputPin<I>
 where
@@ -17,15 +18,21 @@ where
     }
 }
 
-impl<I> InputPin for XiaoSwdInputPin<I>
+impl<I> ErrorType for XiaoSwdInputPin<I>
 where
     I: PinId,
 {
     type Error = core::convert::Infallible;
-    fn is_high(&self) -> Result<bool, Self::Error> {
+}
+
+impl<I> InputPin for XiaoSwdInputPin<I>
+where
+    I: PinId,
+{
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
         self.pin.is_high()
     }
-    fn is_low(&self) -> Result<bool, Self::Error> {
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
         self.pin.is_low()
     }
 }
@@ -34,7 +41,6 @@ impl<I> IoPin<XiaoSwdInputPin<I>, XiaoSwdOutputPin<I>> for XiaoSwdInputPin<I>
 where
     I: PinId,
 {
-    type Error = core::convert::Infallible;
     fn into_input_pin(self) -> Result<XiaoSwdInputPin<I>, Self::Error> {
         Ok(self)
     }
@@ -61,18 +67,24 @@ where
     }
 }
 
-impl<I> OutputPin for XiaoSwdOutputPin<I>
+impl<I> ErrorType for XiaoSwdOutputPin<I>
 where
     I: PinId,
 {
     type Error = core::convert::Infallible;
+}
+
+impl<I> OutputPin for XiaoSwdOutputPin<I>
+where
+    I: PinId,
+{
     fn set_high(&mut self) -> Result<(), Self::Error> {
         self.pin.set_high()
     }
     fn set_low(&mut self) -> Result<(), Self::Error> {
         self.pin.set_low()
     }
-    fn set_state(&mut self, state: embedded_hal::digital::v2::PinState) -> Result<(), Self::Error> {
+    fn set_state(&mut self, state: PinState) -> Result<(), Self::Error> {
         self.pin.set_state(state)
     }
 }
@@ -81,7 +93,6 @@ impl<I> IoPin<XiaoSwdInputPin<I>, XiaoSwdOutputPin<I>> for XiaoSwdOutputPin<I>
 where
     I: PinId,
 {
-    type Error = core::convert::Infallible;
     fn into_input_pin(self) -> Result<XiaoSwdInputPin<I>, Self::Error> {
         let new_pin = self.pin.into_floating_input();
         Ok(XiaoSwdInputPin::new(new_pin))
@@ -99,11 +110,17 @@ where
     pin: Pin<I, Disabled<Floating>>,
 }
 
-impl<I> IoPin<XiaoSwdInputPin<I>, XiaoSwdOutputPin<I>> for XiaoSwdPin<I>
+impl<I> ErrorType for XiaoSwdPin<I>
 where
     I: PinId,
 {
     type Error = core::convert::Infallible;
+}
+
+impl<I> IoPin<XiaoSwdInputPin<I>, XiaoSwdOutputPin<I>> for XiaoSwdPin<I>
+where
+    I: PinId,
+{
     fn into_input_pin(self) -> Result<XiaoSwdInputPin<I>, Self::Error> {
         let input_pin = self.pin.into_floating_input();
         Ok(XiaoSwdInputPin::new(input_pin))

--- a/boards/xiao_rp2040/Cargo.lock
+++ b/boards/xiao_rp2040/Cargo.lock
@@ -45,6 +45,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
+name = "bitfield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,8 +81,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ec610d8f49840a5b376c69663b6369e71f4b34484b9b2eb29fb918d92516cb9"
 dependencies = [
  "bare-metal 0.2.5",
- "bitfield",
- "embedded-hal",
+ "bitfield 0.13.2",
+ "embedded-hal 0.2.7",
  "volatile-register",
 ]
 
@@ -109,7 +115,7 @@ dependencies = [
  "bare-metal 1.0.0",
  "cortex-m",
  "cortex-m-rtic-macros",
- "heapless",
+ "heapless 0.7.16",
  "rtic-core",
  "rtic-monotonic",
  "version_check",
@@ -173,6 +179,37 @@ dependencies = [
  "nb 0.1.3",
  "void",
 ]
+
+[[package]]
+name = "embedded-hal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "embedded-hal-async"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
+dependencies = [
+ "embedded-hal 1.0.0",
+]
+
+[[package]]
+name = "embedded-hal-nb"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba4268c14288c828995299e59b12babdbe170f6c6d73731af1b4648142e8605"
+dependencies = [
+ "embedded-hal 1.0.0",
+ "nb 1.1.0",
+]
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "frunk"
@@ -244,6 +281,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,9 +302,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
  "atomic-polyfill",
- "hash32",
+ "hash32 0.2.1",
  "rustc_version 0.4.0",
  "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -350,6 +406,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -405,9 +467,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rp-pico"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6341771e6f8e5d130b2b3cbc23435b7847761adf198af09f4b2a60407d43bd56"
+checksum = "b9342d3ac7011ac688300979e9b52a81f0add1d05feb02868cf94bfee0705b28"
 dependencies = [
  "cortex-m-rt",
  "fugit",
@@ -426,14 +488,19 @@ dependencies = [
 
 [[package]]
 name = "rp2040-hal"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff2b9ae7e6dd6720fd9f64250c9087260e50fe98b6b032ccca65be3581167ca"
+checksum = "d11e711940087f2cdff8aeae9f4b902e2014c06a00b39a1092686b81ec973d6f"
 dependencies = [
+ "bitfield 0.14.0",
  "cortex-m",
  "critical-section",
  "embedded-dma",
- "embedded-hal",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "embedded-hal-nb",
+ "embedded-io",
  "frunk",
  "fugit",
  "itertools",
@@ -462,9 +529,9 @@ dependencies = [
 
 [[package]]
 name = "rp2040-pac"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d9d8375815f543f54835d01160d4e47f9e2cae75f17ff8f1ec19ce1da96e4c"
+checksum = "83cbcd3f7a0ca7bbe61dc4eb7e202842bee4e27b769a7bf3a4a72fa399d6e404"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -498,29 +565,27 @@ dependencies = [
 
 [[package]]
 name = "rust-dap"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitflags",
  "bitvec",
- "embedded-hal",
- "heapless",
- "nb 0.1.3",
+ "embedded-hal 1.0.0",
+ "heapless 0.7.16",
  "num_enum",
  "usb-device",
 ]
 
 [[package]]
 name = "rust-dap-rp2040"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bitvec",
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-rtic",
- "embedded-hal",
+ "embedded-hal 1.0.0",
  "fugit",
- "heapless",
- "nb 0.1.3",
+ "heapless 0.7.16",
  "panic-halt",
  "pio",
  "rp2040-boot2",
@@ -532,14 +597,14 @@ dependencies = [
 
 [[package]]
 name = "rust-dap-xiao-rp2040"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-rtic",
- "embedded-hal",
- "heapless",
- "nb 0.1.3",
+ "embedded-hal 1.0.0",
+ "embedded-hal-nb",
+ "heapless 0.7.16",
  "panic-halt",
  "rp-pico",
  "rust-dap",
@@ -644,18 +709,23 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "usb-device"
-version = "0.2.9"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
+checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
+dependencies = [
+ "heapless 0.8.0",
+ "portable-atomic",
+]
 
 [[package]]
 name = "usbd-serial"
-version = "0.1.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db75519b86287f12dcf0d171c7cf4ecc839149fe9f3b720ac4cfce52959e1dfe"
+checksum = "065e4eaf93db81d5adac82d9cef8f8da314cb640fa7f89534b972383f1cf80fc"
 dependencies = [
- "embedded-hal",
- "nb 0.1.3",
+ "embedded-hal 0.2.7",
+ "embedded-io",
+ "nb 1.1.0",
  "usb-device",
 ]
 

--- a/boards/xiao_rp2040/Cargo.lock
+++ b/boards/xiao_rp2040/Cargo.lock
@@ -51,6 +51,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,7 +97,7 @@ checksum = "f0f6f3e36f203cfedbc78b357fb28730aa2c6dc1ab060ee5c2405e843988d3c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -113,7 +125,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rtic-syntax",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -163,6 +175,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "frunk"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28aef0f9aa070bce60767c12ba9cb41efeaf1a2bc6427f87b7d83f11239a16d7"
+dependencies = [
+ "frunk_core",
+ "frunk_derives",
+]
+
+[[package]]
+name = "frunk_core"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "476eeaa382e3462b84da5d6ba3da97b5786823c2d0d3a0d04ef088d073da225c"
+
+[[package]]
+name = "frunk_derives"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b4095fc99e1d858e5b8c7125d2638372ec85aa0fe6c807105cf10b0265ca6c"
+dependencies = [
+ "frunk_proc_macro_helpers",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
+name = "frunk_proc_macro_helpers"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1952b802269f2db12ab7c0bd328d0ae8feaabf19f352a7b0af7bb0c5693abfce"
+dependencies = [
+ "frunk_core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
 name = "fugit"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -170,6 +221,12 @@ checksum = "17186ad64927d5ac8f02c1e77ccefa08ccd9eaa314d5a4772278aa204a22f7e7"
 dependencies = [
  "gcd",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "gcd"
@@ -266,7 +323,7 @@ checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -301,7 +358,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -335,6 +392,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,11 +405,10 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rp-pico"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aab28f6f4e19cec2d61b64cdd685e69794b81c579fd3b765579c46018fe616d0"
+checksum = "6341771e6f8e5d130b2b3cbc23435b7847761adf198af09f4b2a60407d43bd56"
 dependencies = [
- "cortex-m",
  "cortex-m-rt",
  "fugit",
  "rp2040-hal",
@@ -364,14 +426,15 @@ dependencies = [
 
 [[package]]
 name = "rp2040-hal"
-version = "0.8.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1369bb84862d7f69391a96606b2f29a00bfce7f29a749e23d5f01fc3f607ada0"
+checksum = "1ff2b9ae7e6dd6720fd9f64250c9087260e50fe98b6b032ccca65be3581167ca"
 dependencies = [
  "cortex-m",
  "critical-section",
  "embedded-dma",
  "embedded-hal",
+ "frunk",
  "fugit",
  "itertools",
  "nb 1.1.0",
@@ -394,17 +457,18 @@ dependencies = [
  "cortex-m-rt",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "rp2040-pac"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9192cafbb40d717c9e0ddf767aaf9c69fee1b4e48d22ed853b57b11f6d9f3d7e"
+checksum = "12d9d8375815f543f54835d01160d4e47f9e2cae75f17ff8f1ec19ce1da96e4c"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
+ "critical-section",
  "vcell",
 ]
 
@@ -429,7 +493,7 @@ dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -437,6 +501,7 @@ name = "rust-dap"
 version = "0.2.0"
 dependencies = [
  "bitflags",
+ "bitvec",
  "embedded-hal",
  "heapless",
  "nb 0.1.3",
@@ -446,8 +511,9 @@ dependencies = [
 
 [[package]]
 name = "rust-dap-rp2040"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
+ "bitvec",
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-rtic",
@@ -466,7 +532,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dap-xiao-rp2040"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "cortex-m",
  "cortex-m-rt",
@@ -554,6 +620,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,4 +684,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ee8f19f9d74293faf70901bc20ad067dc1ad390d2cbf1e3f75f721ffee908b6"
 dependencies = [
  "vcell",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]

--- a/boards/xiao_rp2040/Cargo.toml
+++ b/boards/xiao_rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-dap-xiao-rp2040"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Kenta IDA <fuga@fugafuga.org>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -19,21 +19,21 @@ set_clock = ["rust-dap-rp2040/set_clock"]   # Enable swj_clock implementation fo
 ram-exec = ["rust-dap-rp2040/ram-exec"] # Execute-in-SRAM support
 
 [dependencies.rp-pico]
-version = "0.8"
+version = "0.9"
 # Below is to take out "boot2" from the set of features.
 default-features = false
 features = [ "rt", "critical-section-impl" ]
 
 [dependencies]
-rust-dap = { path = "../../rust-dap", features = ["unproven"] }
+rust-dap = { path = "../../rust-dap" }
 rust-dap-rp2040 = { path = "../../rust-dap-rp2040" }
 panic-halt = "0.2"
 cortex-m = "0.7"
 cortex-m-rt = "0.7"
 cortex-m-rtic = "1.0"
 
-usb-device = { version = "0.2", features = ["control-buffer-256"]}
-usbd-serial = "0.1"
-nb = "0.1"
+usb-device = { version = "0.3", features = ["control-buffer-256"]}
+usbd-serial = "0.2"
 heapless = "0.7"
-embedded-hal = { version = "0.2", features = ["unproven"]}
+embedded-hal = "1"
+embedded-hal-nb = "1"

--- a/boards/xiao_rp2040/Cargo.toml
+++ b/boards/xiao_rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-dap-xiao-rp2040"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Kenta IDA <fuga@fugafuga.org>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -19,7 +19,7 @@ set_clock = ["rust-dap-rp2040/set_clock"]   # Enable swj_clock implementation fo
 ram-exec = ["rust-dap-rp2040/ram-exec"] # Execute-in-SRAM support
 
 [dependencies.rp-pico]
-version = "0.7"
+version = "0.8"
 # Below is to take out "boot2" from the set of features.
 default-features = false
 features = [ "rt", "critical-section-impl" ]

--- a/boards/xiao_rp2040/src/main.rs
+++ b/boards/xiao_rp2040/src/main.rs
@@ -33,8 +33,8 @@ mod app {
     use usb_device::prelude::*;
     use usbd_serial::SerialPort;
 
-    use embedded_hal::digital::v2::{OutputPin, ToggleableOutputPin};
-    use embedded_hal::serial::{Read, Write};
+    use embedded_hal::digital::{OutputPin, StatefulOutputPin};
+    use embedded_hal_nb::serial::{Read, Write};
 
     use rust_dap_rp2040::line_coding::*;
     use rust_dap_rp2040::util::{

--- a/boards/xiao_rp2040/src/main.rs
+++ b/boards/xiao_rp2040/src/main.rs
@@ -22,7 +22,7 @@ mod app {
     use panic_halt as _;
 
     use hal::clocks::Clock;
-    use hal::gpio::{Output, Pin, PushPull};
+    use hal::gpio::{FunctionSioOutput, FunctionUart, Pin, PullDown};
     use hal::pac;
     use rp_pico::hal;
 
@@ -62,8 +62,8 @@ mod app {
     const UART_TX_QUEUE_SIZE: usize = 128;
     // UART Shared context
     type UartPins = (
-        hal::gpio::Pin<GpioUartTx, hal::gpio::Function<hal::gpio::Uart>>,
-        hal::gpio::Pin<GpioUartRx, hal::gpio::Function<hal::gpio::Uart>>,
+        Pin<GpioUartTx, FunctionUart, PullDown>,
+        Pin<GpioUartRx, FunctionUart, PullDown>,
     );
     type Uart = hal::uart::UartPeripheral<hal::uart::Enabled, pac::UART0, UartPins>;
     pub struct UartReader(hal::uart::Reader<pac::UART0, UartPins>);
@@ -89,11 +89,11 @@ mod app {
         uart_rx_producer: heapless::spsc::Producer<'static, u8, UART_RX_QUEUE_SIZE>,
         usb_bus: UsbDevice<'static, UsbBus>,
         usb_dap: CmsisDap<'static, UsbBus, SwdIoSet, 64>,
-        usb_led: Pin<GpioUsbLed, Output<PushPull>>,
-        idle_led: Pin<GpioIdleLed, Output<PushPull>>,
-        debug_out: Pin<GpioDebugOut, Output<PushPull>>,
-        debug_irq_out: Pin<GpioDebugIrqOut, Output<PushPull>>,
-        debug_usb_irq_out: Pin<GpioDebugUsbIrqOut, Output<PushPull>>,
+        usb_led: Pin<GpioUsbLed, FunctionSioOutput, PullDown>,
+        idle_led: Pin<GpioIdleLed, FunctionSioOutput, PullDown>,
+        debug_out: Pin<GpioDebugOut, FunctionSioOutput, PullDown>,
+        debug_irq_out: Pin<GpioDebugIrqOut, FunctionSioOutput, PullDown>,
+        debug_usb_irq_out: Pin<GpioDebugUsbIrqOut, FunctionSioOutput, PullDown>,
     }
 
     #[init(local = [
@@ -125,8 +125,8 @@ mod app {
         .unwrap();
 
         let uart_pins = (
-            pins.gpio0.into_mode::<hal::gpio::FunctionUart>(), // TxD
-            pins.gpio1.into_mode::<hal::gpio::FunctionUart>(), // RxD
+            pins.gpio0.reconfigure(), // TxD
+            pins.gpio1.reconfigure(), // RxD
         );
         let uart_config = UartConfigAndClock {
             config: UartConfig::from(hal::uart::UartConfig::default()),
@@ -168,9 +168,9 @@ mod app {
             }
             #[cfg(not(feature = "bitbang"))]
             {
-                let mut swclk_pin = pins.gpio2.into_mode();
-                let mut swdio_pin = pins.gpio4.into_mode();
-                let mut reset_pin = reset_pin.into_mode();
+                let mut swclk_pin = pins.gpio2.reconfigure();
+                let mut swdio_pin = pins.gpio4.reconfigure();
+                let mut reset_pin = reset_pin.reconfigure();
                 swclk_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
                 swdio_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);
                 reset_pin.set_slew_rate(hal::gpio::OutputSlewRate::Fast);

--- a/rust-dap-rp2040/Cargo.lock
+++ b/rust-dap-rp2040/Cargo.lock
@@ -207,6 +207,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "frunk"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28aef0f9aa070bce60767c12ba9cb41efeaf1a2bc6427f87b7d83f11239a16d7"
+dependencies = [
+ "frunk_core",
+ "frunk_derives",
+]
+
+[[package]]
+name = "frunk_core"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "476eeaa382e3462b84da5d6ba3da97b5786823c2d0d3a0d04ef088d073da225c"
+
+[[package]]
+name = "frunk_derives"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b4095fc99e1d858e5b8c7125d2638372ec85aa0fe6c807105cf10b0265ca6c"
+dependencies = [
+ "frunk_proc_macro_helpers",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
+name = "frunk_proc_macro_helpers"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1952b802269f2db12ab7c0bd328d0ae8feaabf19f352a7b0af7bb0c5693abfce"
+dependencies = [
+ "frunk_core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
 name = "fugit"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,14 +446,15 @@ dependencies = [
 
 [[package]]
 name = "rp2040-hal"
-version = "0.8.2"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1369bb84862d7f69391a96606b2f29a00bfce7f29a749e23d5f01fc3f607ada0"
+checksum = "1ff2b9ae7e6dd6720fd9f64250c9087260e50fe98b6b032ccca65be3581167ca"
 dependencies = [
  "cortex-m",
  "critical-section",
  "embedded-dma",
  "embedded-hal",
+ "frunk",
  "fugit",
  "itertools",
  "nb 1.1.0",
@@ -442,11 +482,12 @@ dependencies = [
 
 [[package]]
 name = "rp2040-pac"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9192cafbb40d717c9e0ddf767aaf9c69fee1b4e48d22ed853b57b11f6d9f3d7e"
+checksum = "12d9d8375815f543f54835d01160d4e47f9e2cae75f17ff8f1ec19ce1da96e4c"
 dependencies = [
  "cortex-m",
+ "critical-section",
  "vcell",
 ]
 
@@ -489,7 +530,7 @@ dependencies = [
 
 [[package]]
 name = "rust-dap-rp2040"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitvec",
  "cortex-m",

--- a/rust-dap-rp2040/Cargo.lock
+++ b/rust-dap-rp2040/Cargo.lock
@@ -45,6 +45,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
 
 [[package]]
+name = "bitfield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,8 +81,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ec610d8f49840a5b376c69663b6369e71f4b34484b9b2eb29fb918d92516cb9"
 dependencies = [
  "bare-metal 0.2.5",
- "bitfield",
- "embedded-hal",
+ "bitfield 0.13.2",
+ "embedded-hal 0.2.7",
  "volatile-register",
 ]
 
@@ -109,7 +115,7 @@ dependencies = [
  "bare-metal 1.0.0",
  "cortex-m",
  "cortex-m-rtic-macros",
- "heapless",
+ "heapless 0.7.16",
  "rtic-core",
  "rtic-monotonic",
  "version_check",
@@ -207,6 +213,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "embedded-hal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
+
+[[package]]
+name = "embedded-hal-async"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4c685bbef7fe13c3c6dd4da26841ed3980ef33e841cddfa15ce8a8fb3f1884"
+dependencies = [
+ "embedded-hal 1.0.0",
+]
+
+[[package]]
+name = "embedded-hal-nb"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fba4268c14288c828995299e59b12babdbe170f6c6d73731af1b4648142e8605"
+dependencies = [
+ "embedded-hal 1.0.0",
+ "nb 1.1.0",
+]
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "frunk"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +313,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,9 +334,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
  "atomic-polyfill",
- "hash32",
+ "hash32 0.2.1",
  "rustc_version 0.4.0",
  "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -382,6 +438,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,14 +508,19 @@ dependencies = [
 
 [[package]]
 name = "rp2040-hal"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff2b9ae7e6dd6720fd9f64250c9087260e50fe98b6b032ccca65be3581167ca"
+checksum = "d11e711940087f2cdff8aeae9f4b902e2014c06a00b39a1092686b81ec973d6f"
 dependencies = [
+ "bitfield 0.14.0",
  "cortex-m",
  "critical-section",
  "embedded-dma",
- "embedded-hal",
+ "embedded-hal 0.2.7",
+ "embedded-hal 1.0.0",
+ "embedded-hal-async",
+ "embedded-hal-nb",
+ "embedded-io",
  "frunk",
  "fugit",
  "itertools",
@@ -482,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "rp2040-pac"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12d9d8375815f543f54835d01160d4e47f9e2cae75f17ff8f1ec19ce1da96e4c"
+checksum = "83cbcd3f7a0ca7bbe61dc4eb7e202842bee4e27b769a7bf3a4a72fa399d6e404"
 dependencies = [
  "cortex-m",
  "critical-section",
@@ -517,30 +584,28 @@ dependencies = [
 
 [[package]]
 name = "rust-dap"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitflags",
  "bitvec",
- "embedded-hal",
- "heapless",
- "nb 0.1.3",
+ "embedded-hal 1.0.0",
+ "heapless 0.7.16",
  "num_enum",
  "usb-device",
 ]
 
 [[package]]
 name = "rust-dap-rp2040"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bitvec",
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-rtic",
  "defmt",
- "embedded-hal",
+ "embedded-hal 1.0.0",
  "fugit",
- "heapless",
- "nb 0.1.3",
+ "heapless 0.7.16",
  "panic-halt",
  "pio",
  "rp2040-boot2",
@@ -666,18 +731,23 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "usb-device"
-version = "0.2.9"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
+checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
+dependencies = [
+ "heapless 0.8.0",
+ "portable-atomic",
+]
 
 [[package]]
 name = "usbd-serial"
-version = "0.1.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db75519b86287f12dcf0d171c7cf4ecc839149fe9f3b720ac4cfce52959e1dfe"
+checksum = "065e4eaf93db81d5adac82d9cef8f8da314cb640fa7f89534b972383f1cf80fc"
 dependencies = [
- "embedded-hal",
- "nb 0.1.3",
+ "embedded-hal 0.2.7",
+ "embedded-io",
+ "nb 1.1.0",
  "usb-device",
 ]
 

--- a/rust-dap-rp2040/Cargo.toml
+++ b/rust-dap-rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-dap-rp2040"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Kenta IDA <fuga@fugafuga.org>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -17,7 +17,7 @@ defmt = ["dep:defmt"]
 [dependencies]
 rust-dap = { path = "../rust-dap" }
 rp2040-boot2 = "0.2"
-rp2040-hal = "0.8"
+rp2040-hal = "0.9"
 pio = "0.2"
 panic-halt = "0.2"
 cortex-m = "0.7"

--- a/rust-dap-rp2040/Cargo.toml
+++ b/rust-dap-rp2040/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-dap-rp2040"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Kenta IDA <fuga@fugafuga.org>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-bitbang = ["rust-dap/bitbang", "rust-dap/unproven"]
+bitbang = ["embedded-hal", "rust-dap/bitbang"]
 set_clock = [
 ] # Enable swj_clock implementation for bitbang and PIO and set appropriate SWCLK frequency. Otherwise, SWCLK is fixed to 15.625[MHz]
 ram-exec = [] # Execute-in-SRAM support
@@ -17,18 +17,17 @@ defmt = ["dep:defmt"]
 [dependencies]
 rust-dap = { path = "../rust-dap" }
 rp2040-boot2 = "0.2"
-rp2040-hal = "0.9"
+rp2040-hal = "0.10"
 pio = "0.2"
 panic-halt = "0.2"
 cortex-m = "0.7"
 cortex-m-rt = "0.7"
 cortex-m-rtic = "1.0"
 
-usb-device = { version = "0.2", features = ["control-buffer-256"] }
-usbd-serial = "0.1"
-nb = "0.1"
+usb-device = { version = "0.3", features = ["control-buffer-256"] }
+usbd-serial = "0.2"
 heapless = "0.7"
-embedded-hal = { version = "0.2", features = ["unproven"] }
+embedded-hal = { version = "1", optional = true }
 fugit = "0.3"
 defmt = { version = "0.3", optional = true }
 bitvec = { version = "1.0.1", default-features = false }

--- a/rust-dap-rp2040/src/lib.rs
+++ b/rust-dap-rp2040/src/lib.rs
@@ -36,6 +36,7 @@ pub static BOOT2_FIRMWARE: [u8; 256] = rp2040_boot2::BOOT_LOADER_W25Q080;
 pub mod line_coding;
 #[cfg(not(feature = "bitbang"))]
 pub mod pio;
+#[cfg(feature = "bitbang")]
 pub mod swdio_pin;
 pub mod util;
 

--- a/rust-dap-rp2040/src/line_coding.rs
+++ b/rust-dap-rp2040/src/line_coding.rs
@@ -100,7 +100,7 @@ impl From<UartParityType> for usbd_serial::ParityType {
     fn from(value: UartParityType) -> Self {
         match value {
             UartParityType::None => Self::None,
-            UartParityType::Even => Self::Event,
+            UartParityType::Even => Self::Even,
             UartParityType::Odd => Self::Odd,
         }
     }
@@ -110,7 +110,7 @@ impl TryFrom<usbd_serial::ParityType> for UartParityType {
     fn try_from(value: usbd_serial::ParityType) -> Result<Self, Self::Error> {
         match value {
             usbd_serial::ParityType::None => Ok(Self::None),
-            usbd_serial::ParityType::Event => Ok(Self::Even),
+            usbd_serial::ParityType::Even => Ok(Self::Even),
             usbd_serial::ParityType::Odd => Ok(Self::Odd),
             _ => Err(Self::Error::Incompatible),
         }

--- a/rust-dap-rp2040/src/pio/jtag.rs
+++ b/rust-dap-rp2040/src/pio/jtag.rs
@@ -16,15 +16,15 @@
 
 use cortex_m::asm;
 use hal::{
-    gpio::{bank0, PinId},
+    gpio::PinId,
     pac::{self, PIO0},
     pio::PIOExt,
 };
 use rp2040_hal as hal;
 use rust_dap::*;
 pub mod pio0 {
-    use crate::pio::hal::{self, gpio::FunctionPio0};
-    pub type Pin<P> = hal::gpio::Pin<P, FunctionPio0>;
+    use crate::pio::hal::{self, gpio::FunctionPio0, gpio::PullUp};
+    pub type Pin<P> = hal::gpio::Pin<P, FunctionPio0, PullUp>;
 }
 use bitvec::prelude::*;
 
@@ -153,34 +153,34 @@ impl<Tck, Tms, Tdi, Tdo, Trst, Srst>
         pio0::Pin<Srst>,
     >
 where
-    Tck: PinId + bank0::BankPinId,
-    Tms: PinId + bank0::BankPinId,
-    Tdi: PinId + bank0::BankPinId,
-    Tdo: PinId + bank0::BankPinId,
-    Trst: PinId + bank0::BankPinId,
-    Srst: PinId + bank0::BankPinId,
+    Tck: PinId,
+    Tms: PinId,
+    Tdi: PinId,
+    Tdo: PinId,
+    Trst: PinId,
+    Srst: PinId,
 {
     pub fn new(
         pio0: pac::PIO0,
-        _tck: pio0::Pin<Tck>,
-        _tms: pio0::Pin<Tms>,
-        _tdi: pio0::Pin<Tdi>,
-        _tdo: pio0::Pin<Tdo>,
+        tck: pio0::Pin<Tck>,
+        tms: pio0::Pin<Tms>,
+        tdi: pio0::Pin<Tdi>,
+        tdo: pio0::Pin<Tdo>,
         trst: Option<pio0::Pin<Trst>>,
         srst: Option<pio0::Pin<Srst>>,
         resets: &mut pac::RESETS,
     ) -> Self {
-        let tck_pin_id = Tck::DYN.num;
-        let tms_pin_id = Tms::DYN.num;
-        let tdi_pin_id = Tdi::DYN.num;
-        let tdo_pin_id = Tdo::DYN.num;
-        let trst_pin_id = if trst.is_some() {
-            Some(Trst::DYN.num)
+        let tck_pin_id = tck.id().num;
+        let tms_pin_id = tms.id().num;
+        let tdi_pin_id = tdi.id().num;
+        let tdo_pin_id = tdo.id().num;
+        let trst_pin_id = if let Some(trst) = trst {
+            Some(trst.id().num)
         } else {
             None
         };
-        let srst_pin_id: Option<u8> = if srst.is_some() {
-            Some(Srst::DYN.num)
+        let srst_pin_id: Option<u8> = if let Some(srst) = srst {
+            Some(srst.id().num)
         } else {
             None
         };

--- a/rust-dap-rp2040/src/pio/jtag.rs
+++ b/rust-dap-rp2040/src/pio/jtag.rs
@@ -191,7 +191,7 @@ where
         // Initialize and start PIO
         let (mut pio, sm0, _, _, _) = pio0.split(resets);
         let installed = pio.install(&program).unwrap();
-        let (sm, rx, tx) = hal::pio::PIOBuilder::from_program(installed)
+        let (sm, rx, tx) = hal::pio::PIOBuilder::from_installed_program(installed)
             .set_pins(tms_pin_id, 1)
             .side_set_pin_base(tck_pin_id)
             .out_pins(tdi_pin_id, 1)
@@ -248,7 +248,7 @@ impl<Tck, Tms, Tdi, Tdo, Trst, Srst> JtagIoSet<Tck, Tms, Tdi, Tdo, Trst, Srst> {
         core::mem::swap(&mut self.context, &mut context);
         let context = context.unwrap();
         let (sm0, installed) = context.running_sm.uninit(context.rx_fifo, context.tx_fifo);
-        let (sm, rx, tx) = hal::pio::PIOBuilder::from_program(installed)
+        let (sm, rx, tx) = hal::pio::PIOBuilder::from_installed_program(installed)
             .set_pins(self.tms_pin_id, 1)
             .side_set_pin_base(self.tck_pin_id)
             .out_pins(self.tdi_pin_id, 1)
@@ -288,7 +288,7 @@ impl<Tck, Tms, Tdi, Tdo, Trst, Srst> JtagIoSet<Tck, Tms, Tdi, Tdo, Trst, Srst> {
         let mut pio = context.pio;
         pio.uninstall(installed);
         let installed = pio.install(&swj_pins_program()).unwrap();
-        let (sm, rx_fifo, tx_fifo) = hal::pio::PIOBuilder::from_program(installed)
+        let (sm, rx_fifo, tx_fifo) = hal::pio::PIOBuilder::from_installed_program(installed)
             .set_pins(0, 1)
             .side_set_pin_base(0)
             .out_pins(0, 32)
@@ -317,7 +317,7 @@ impl<Tck, Tms, Tdi, Tdo, Trst, Srst> JtagIoSet<Tck, Tms, Tdi, Tdo, Trst, Srst> {
         pio.uninstall(installed);
         let installed = pio.install(&jtag_pin_set()).unwrap();
         let divisor = crate::pio::DEFAULT_PIO_DIVISOR;
-        let (sm, rx_fifo, tx_fifo) = hal::pio::PIOBuilder::from_program(installed)
+        let (sm, rx_fifo, tx_fifo) = hal::pio::PIOBuilder::from_installed_program(installed)
             .set_pins(0, 1)
             .side_set_pin_base(0)
             .out_pins(0, 32)
@@ -346,7 +346,7 @@ impl<Tck, Tms, Tdi, Tdo, Trst, Srst> JtagIoSet<Tck, Tms, Tdi, Tdo, Trst, Srst> {
         pio.uninstall(installed);
         let installed = pio.install(&jtag_sequence_program()).unwrap();
         let divisor = self.divisor;
-        let (sm, rx_fifo, tx_fifo) = hal::pio::PIOBuilder::from_program(installed)
+        let (sm, rx_fifo, tx_fifo) = hal::pio::PIOBuilder::from_installed_program(installed)
             .set_pins(self.tms_pin_id, 1)
             .side_set_pin_base(self.tck_pin_id)
             .out_pins(self.tdi_pin_id, 1)

--- a/rust-dap-rp2040/src/pio/mod.rs
+++ b/rust-dap-rp2040/src/pio/mod.rs
@@ -18,8 +18,8 @@
 use pio::Program;
 use rp2040_hal as hal;
 pub mod pio0 {
-    use crate::pio::hal::{self, gpio::FunctionPio0};
-    pub type Pin<P> = hal::gpio::Pin<P, FunctionPio0>;
+    use crate::pio::hal::{self, gpio::FunctionPio0, gpio::PullUp};
+    pub type Pin<P> = hal::gpio::Pin<P, FunctionPio0, PullUp>;
 }
 
 pub mod jtag;

--- a/rust-dap-rp2040/src/pio/swd.rs
+++ b/rust-dap-rp2040/src/pio/swd.rs
@@ -20,7 +20,7 @@ use rust_dap::*;
 // use rust_dap::{SwdIo, SwdIoConfig, SwdRequest, DapError};
 // use rust_dap::{DAP_TRANSFER_OK, DAP_TRANSFER_WAIT, DAP_TRANSFER_FAULT, /* DAP_TRANSFER_ERROR, */ DAP_TRANSFER_MISMATCH};
 use crate::pio::*;
-use hal::gpio::{bank0, PinId};
+use hal::gpio::PinId;
 use hal::pac::{self, PIO0};
 use hal::pio::{InstalledProgram, PIOExt};
 
@@ -172,15 +172,15 @@ fn swd_program() -> Program<{ pio::RP2040_MAX_PROGRAM_SIZE }> {
 
 impl<C, D, E> SwdIoSet<pio0::Pin<C>, pio0::Pin<D>, pio0::Pin<E>>
 where
-    C: PinId + bank0::BankPinId,
-    D: PinId + bank0::BankPinId,
-    E: PinId + bank0::BankPinId,
+    C: PinId,
+    D: PinId,
+    E: PinId,
 {
     #[rustfmt::skip]
-    pub fn new(pio0: pac::PIO0, _: pio0::Pin<C>, _: pio0::Pin<D>, _: pio0::Pin<E>, resets: &mut pac::RESETS) -> Self {
-        let clk_pin_id = C::DYN.num;
-        let dat_pin_id = D::DYN.num;
-        let rst_pin_id = E::DYN.num;
+    pub fn new(pio0: pac::PIO0, c: pio0::Pin<C>, d: pio0::Pin<D>, e: pio0::Pin<E>, resets: &mut pac::RESETS) -> Self {
+        let clk_pin_id = c.id().num;
+        let dat_pin_id = d.id().num;
+        let rst_pin_id = e.id().num;
         // Currently HAL does not provide any way to disable schmitt trigger.
         // unsafe { core::ptr::write_volatile((0x4001C004 + clk_pin_id as u32 * 4) as *mut u32, 0x71 as u32) };
         // unsafe { core::ptr::write_volatile((0x4001C004 + dat_pin_id as u32 * 4) as *mut u32, 0x71 as u32); }

--- a/rust-dap-rp2040/src/pio/swd.rs
+++ b/rust-dap-rp2040/src/pio/swd.rs
@@ -243,7 +243,7 @@ impl<C, D, E> SwdIoSet<C, D, E> {
         hal::pio::Rx<(P, hal::pio::SM0)>,
         hal::pio::Tx<(P, hal::pio::SM0)>,
     ) {
-        hal::pio::PIOBuilder::from_program(installed)
+        hal::pio::PIOBuilder::from_installed_program(installed)
             .set_pins(set_pin_id, set_pin_count)
             .side_set_pin_base(side_set_pin_id)
             .out_pins(out_pins_id, out_pins_count)

--- a/rust-dap-rp2040/src/swdio_pin.rs
+++ b/rust-dap-rp2040/src/swdio_pin.rs
@@ -14,10 +14,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use embedded_hal::digital::v2::{InputPin, IoPin, OutputPin, PinState};
+use embedded_hal::digital::{ErrorType, InputPin, OutputPin, PinState};
 use hal::gpio::{FunctionNull, FunctionSioInput, FunctionSioOutput};
 use hal::gpio::{Pin, PinId, PullNone, ValidFunction};
 use rp2040_hal as hal;
+use rust_dap::bitbang::IoPin;
 
 /// InputPin implementation for SWD pin
 pub struct PicoSwdInputPin<I>
@@ -25,6 +26,13 @@ where
     I: PinId,
 {
     pin: Pin<I, FunctionSioInput, PullNone>,
+}
+
+impl<I> ErrorType for PicoSwdInputPin<I>
+where
+    I: PinId + ValidFunction<FunctionSioInput>,
+{
+    type Error = core::convert::Infallible;
 }
 
 impl<I> PicoSwdInputPin<I>
@@ -40,11 +48,10 @@ impl<I> InputPin for PicoSwdInputPin<I>
 where
     I: PinId + ValidFunction<FunctionSioInput>,
 {
-    type Error = core::convert::Infallible;
-    fn is_high(&self) -> Result<bool, Self::Error> {
+    fn is_high(&mut self) -> Result<bool, Self::Error> {
         self.pin.is_high()
     }
-    fn is_low(&self) -> Result<bool, Self::Error> {
+    fn is_low(&mut self) -> Result<bool, Self::Error> {
         self.pin.is_low()
     }
 }
@@ -53,7 +60,6 @@ impl<I> IoPin<PicoSwdInputPin<I>, PicoSwdOutputPin<I>> for PicoSwdInputPin<I>
 where
     I: PinId + ValidFunction<FunctionSioInput> + ValidFunction<FunctionSioOutput>,
 {
-    type Error = core::convert::Infallible;
     fn into_input_pin(self) -> Result<PicoSwdInputPin<I>, Self::Error> {
         Ok(self)
     }
@@ -71,6 +77,13 @@ where
     pin: Pin<I, FunctionSioOutput, PullNone>,
 }
 
+impl<I> ErrorType for PicoSwdOutputPin<I>
+where
+    I: PinId + ValidFunction<FunctionSioOutput>,
+{
+    type Error = core::convert::Infallible;
+}
+
 impl<I> PicoSwdOutputPin<I>
 where
     I: PinId + ValidFunction<FunctionSioOutput>,
@@ -84,7 +97,6 @@ impl<I> OutputPin for PicoSwdOutputPin<I>
 where
     I: PinId + ValidFunction<FunctionSioOutput>,
 {
-    type Error = core::convert::Infallible;
     fn set_high(&mut self) -> Result<(), Self::Error> {
         self.pin.set_high()
     }
@@ -100,7 +112,6 @@ impl<I> IoPin<PicoSwdInputPin<I>, PicoSwdOutputPin<I>> for PicoSwdOutputPin<I>
 where
     I: PinId + ValidFunction<FunctionSioInput> + ValidFunction<FunctionSioOutput>,
 {
-    type Error = core::convert::Infallible;
     fn into_input_pin(self) -> Result<PicoSwdInputPin<I>, Self::Error> {
         let input_pin = self.pin.into_floating_input();
         Ok(PicoSwdInputPin::new(input_pin))
@@ -119,11 +130,17 @@ where
     pin: Pin<I, FunctionNull, PullNone>,
 }
 
-impl<I> IoPin<PicoSwdInputPin<I>, PicoSwdOutputPin<I>> for PicoSwdPin<I>
+impl<I> ErrorType for PicoSwdPin<I>
 where
     I: PinId + ValidFunction<FunctionSioInput> + ValidFunction<FunctionSioOutput>,
 {
     type Error = core::convert::Infallible;
+}
+
+impl<I> IoPin<PicoSwdInputPin<I>, PicoSwdOutputPin<I>> for PicoSwdPin<I>
+where
+    I: PinId + ValidFunction<FunctionSioInput> + ValidFunction<FunctionSioOutput>,
+{
     fn into_input_pin(self) -> Result<PicoSwdInputPin<I>, Self::Error> {
         let input_pin = self.pin.into_floating_input();
         Ok(PicoSwdInputPin::new(input_pin))

--- a/rust-dap-rp2040/src/swdio_pin.rs
+++ b/rust-dap-rp2040/src/swdio_pin.rs
@@ -15,7 +15,8 @@
 // limitations under the License.
 
 use embedded_hal::digital::v2::{InputPin, IoPin, OutputPin, PinState};
-use hal::gpio::{Disabled, Floating, Input, Output, Pin, PinId, PushPull};
+use hal::gpio::{FunctionNull, FunctionSioInput, FunctionSioOutput};
+use hal::gpio::{Pin, PinId, PullNone, ValidFunction};
 use rp2040_hal as hal;
 
 /// InputPin implementation for SWD pin
@@ -23,21 +24,21 @@ pub struct PicoSwdInputPin<I>
 where
     I: PinId,
 {
-    pin: Pin<I, Input<Floating>>,
+    pin: Pin<I, FunctionSioInput, PullNone>,
 }
 
 impl<I> PicoSwdInputPin<I>
 where
-    I: PinId,
+    I: PinId + ValidFunction<FunctionSioInput>,
 {
-    pub fn new(pin: Pin<I, Input<Floating>>) -> Self {
+    pub fn new(pin: Pin<I, FunctionSioInput, PullNone>) -> Self {
         Self { pin }
     }
 }
 
 impl<I> InputPin for PicoSwdInputPin<I>
 where
-    I: PinId,
+    I: PinId + ValidFunction<FunctionSioInput>,
 {
     type Error = core::convert::Infallible;
     fn is_high(&self) -> Result<bool, Self::Error> {
@@ -50,7 +51,7 @@ where
 
 impl<I> IoPin<PicoSwdInputPin<I>, PicoSwdOutputPin<I>> for PicoSwdInputPin<I>
 where
-    I: PinId,
+    I: PinId + ValidFunction<FunctionSioInput> + ValidFunction<FunctionSioOutput>,
 {
     type Error = core::convert::Infallible;
     fn into_input_pin(self) -> Result<PicoSwdInputPin<I>, Self::Error> {
@@ -67,21 +68,21 @@ pub struct PicoSwdOutputPin<I>
 where
     I: PinId,
 {
-    pin: Pin<I, Output<PushPull>>,
+    pin: Pin<I, FunctionSioOutput, PullNone>,
 }
 
 impl<I> PicoSwdOutputPin<I>
 where
-    I: PinId,
+    I: PinId + ValidFunction<FunctionSioOutput>,
 {
-    pub fn new(pin: Pin<I, Output<PushPull>>) -> Self {
+    pub fn new(pin: Pin<I, FunctionSioOutput, PullNone>) -> Self {
         Self { pin }
     }
 }
 
 impl<I> OutputPin for PicoSwdOutputPin<I>
 where
-    I: PinId,
+    I: PinId + ValidFunction<FunctionSioOutput>,
 {
     type Error = core::convert::Infallible;
     fn set_high(&mut self) -> Result<(), Self::Error> {
@@ -90,14 +91,14 @@ where
     fn set_low(&mut self) -> Result<(), Self::Error> {
         self.pin.set_low()
     }
-    fn set_state(&mut self, state: embedded_hal::digital::v2::PinState) -> Result<(), Self::Error> {
+    fn set_state(&mut self, state: PinState) -> Result<(), Self::Error> {
         self.pin.set_state(state)
     }
 }
 
 impl<I> IoPin<PicoSwdInputPin<I>, PicoSwdOutputPin<I>> for PicoSwdOutputPin<I>
 where
-    I: PinId,
+    I: PinId + ValidFunction<FunctionSioInput> + ValidFunction<FunctionSioOutput>,
 {
     type Error = core::convert::Infallible;
     fn into_input_pin(self) -> Result<PicoSwdInputPin<I>, Self::Error> {
@@ -115,12 +116,12 @@ pub struct PicoSwdPin<I>
 where
     I: PinId,
 {
-    pin: Pin<I, Disabled<Floating>>,
+    pin: Pin<I, FunctionNull, PullNone>,
 }
 
 impl<I> IoPin<PicoSwdInputPin<I>, PicoSwdOutputPin<I>> for PicoSwdPin<I>
 where
-    I: PinId,
+    I: PinId + ValidFunction<FunctionSioInput> + ValidFunction<FunctionSioOutput>,
 {
     type Error = core::convert::Infallible;
     fn into_input_pin(self) -> Result<PicoSwdInputPin<I>, Self::Error> {

--- a/rust-dap-rp2040/src/util.rs
+++ b/rust-dap-rp2040/src/util.rs
@@ -21,7 +21,7 @@ use rp2040_hal as hal;
 use rust_dap::{
     CmsisDap, DapCapabilities, USB_CLASS_MISCELLANEOUS, USB_PROTOCOL_IAD, USB_SUBCLASS_COMMON,
 };
-use usb_device::device::{UsbDevice, UsbDeviceBuilder, UsbVidPid};
+use usb_device::device::{StringDescriptors, UsbDevice, UsbDeviceBuilder, UsbVidPid};
 use usb_device::{class_prelude::UsbBusAllocator, UsbError};
 use usbd_serial::SerialPort;
 
@@ -147,14 +147,17 @@ where
     let usb_serial = SerialPort::new(usb_allocator);
     let usb_dap = CmsisDap::new(usb_allocator, io, capabilities);
     let usb_bus = UsbDeviceBuilder::new(usb_allocator, UsbVidPid(0x6666, 0x4444))
-        .manufacturer("fugafuga.org")
-        .product("CMSIS-DAP")
-        .serial_number(serial)
+        .strings(&[StringDescriptors::default()
+            .manufacturer("fugafuga.org")
+            .product("CMSIS-DAP")
+            .serial_number(serial)])
+        .unwrap()
         .device_class(USB_CLASS_MISCELLANEOUS)
         .device_class(USB_SUBCLASS_COMMON)
         .device_protocol(USB_PROTOCOL_IAD)
         .composite_with_iads()
         .max_packet_size_0(64)
+        .unwrap()
         .build();
     (usb_serial, usb_dap, usb_bus)
 }

--- a/rust-dap/Cargo.lock
+++ b/rust-dap/Cargo.lock
@@ -81,13 +81,9 @@ dependencies = [
 
 [[package]]
 name = "embedded-hal"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35949884794ad573cf46071e41c9b60efb0cb311e3ca01f7af807af1debc66ff"
-dependencies = [
- "nb 0.1.3",
- "void",
-]
+checksum = "361a90feb7004eca4019fb28352a9465666b24f840f5c3cddf0ff13920590b89"
 
 [[package]]
 name = "funty"
@@ -105,15 +101,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "heapless"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
 dependencies = [
  "atomic-polyfill",
- "hash32",
+ "hash32 0.2.1",
  "rustc_version",
  "spin",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32 0.3.1",
  "stable_deref_trait",
 ]
 
@@ -126,21 +141,6 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
-
-[[package]]
-name = "nb"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
-dependencies = [
- "nb 1.1.0",
-]
-
-[[package]]
-name = "nb"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
 name = "num_enum"
@@ -161,6 +161,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "proc-macro-error"
@@ -212,14 +218,13 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rust-dap"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bitflags",
  "bitvec",
  "defmt",
  "embedded-hal",
- "heapless",
- "nb 0.1.3",
+ "heapless 0.7.16",
  "num_enum",
  "usb-device",
 ]
@@ -316,21 +321,19 @@ checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "usb-device"
-version = "0.2.9"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
+checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
+dependencies = [
+ "heapless 0.8.0",
+ "portable-atomic",
+]
 
 [[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wyz"

--- a/rust-dap/Cargo.toml
+++ b/rust-dap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-dap"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Kenta IDA <fuga@fugafuga.org>"]
 edition = "2021"
 license = "Apache-2.0"
@@ -9,15 +9,13 @@ license = "Apache-2.0"
 [features]
 default = []
 bitbang = ["embedded-hal"]
-unproven = []
 defmt = ["dep:defmt"]
 
 [dependencies]
 defmt = { version = "0.3", optional = true }
-usb-device = "0.2"
-nb = "0.1"
+usb-device = "0.3"
 heapless = "0.7"
 num_enum = { version = "0.5", default-features = false }
 bitflags = "1.2"
-embedded-hal = { version = "0.2", optional = true, features = ["unproven"] }
+embedded-hal = { version = "1", optional = true }
 bitvec = { version = "1.0.1", default-features = false }

--- a/rust-dap/src/bitbang.rs
+++ b/rust-dap/src/bitbang.rs
@@ -15,15 +15,32 @@
 // limitations under the License.
 
 use crate::cmsis_dap::*;
-use bitflags::bitflags;
 use bitvec::slice::BitSlice;
-use embedded_hal::digital::v2::{InputPin, IoPin, OutputPin, PinState};
+use embedded_hal::digital::{ErrorType, InputPin, OutputPin, PinState};
 
 pub trait DelayFunc {
     fn calculate_half_clock_cycles(_frequency_hz: u32) -> Option<u32> {
         None
     }
     fn cycle_delay(&self, cycles: u32);
+}
+
+// A copy of digital::v2::IoPin taken from embedded-hal = "0.2" .
+pub trait IoPin<TInput, TOutput>: ErrorType
+where
+    TInput: InputPin + IoPin<TInput, TOutput>,
+    TOutput: OutputPin + IoPin<TInput, TOutput>,
+{
+    /// Tries to convert this pin to input mode.
+    ///
+    /// If the pin is already in input mode, this method should succeed.
+    fn into_input_pin(self) -> Result<TInput, Self::Error>;
+
+    /// Tries to convert this pin to output mode with the given initial state.
+    ///
+    /// If the pin is already in the requested state, this method should
+    /// succeed.
+    fn into_output_pin(self, state: PinState) -> Result<TOutput, Self::Error>;
 }
 
 fn turn_to_in<I: InputPin + IoPin<I, O>, O: OutputPin + IoPin<I, O>>(

--- a/rust-dap/src/cmsis_dap.rs
+++ b/rust-dap/src/cmsis_dap.rs
@@ -1272,7 +1272,7 @@ where
     fn get_bos_descriptors(&self, writer: &mut BosWriter) -> Result<()> {
         self.inner.get_bos_descriptors(writer)
     }
-    fn get_string(&self, index: StringIndex, lang_id: u16) -> Option<&str> {
+    fn get_string(&self, index: StringIndex, lang_id: LangID) -> Option<&str> {
         self.inner.get_string(index, lang_id)
     }
     fn reset(&mut self) {
@@ -1577,18 +1577,22 @@ mod test {
         }
         dummy_usb_interface.read_buffer_size = 10;
         // no SWDIO Data
+        let usb_strings = StringDescriptors::default()
+            .manufacturer("fugafuga.org")
+            .product("CMSIS-DAP")
+            .serial_number("serialnumber");
         let usb = UsbBusAllocator::new(dummy_usb_interface);
         let mut dap: CmsisDap<DummyUsbInterface, DummyIo, 64> =
             CmsisDap::new(&usb, io, DapCapabilities::SWD);
         UsbDeviceBuilder::new(&usb, UsbVidPid(0x6666, 0x4444))
-            .manufacturer("fugafuga.org")
-            .product("CMSIS-DAP")
-            .serial_number("serialnumber")
+            .strings(&[usb_strings])
+            .unwrap()
             .device_class(USB_CLASS_MISCELLANEOUS)
             .device_class(USB_SUBCLASS_COMMON)
             .device_protocol(USB_PROTOCOL_IAD)
             .composite_with_iads()
             .max_packet_size_0(64)
+            .unwrap()
             .build();
         assert!(dap.process().is_ok());
 
@@ -1611,14 +1615,14 @@ mod test {
         let mut dap: CmsisDap<DummyUsbInterface, DummyIo, 64> =
             CmsisDap::new(&usb, io, DapCapabilities::SWD);
         UsbDeviceBuilder::new(&usb, UsbVidPid(0x6666, 0x4444))
-            .manufacturer("fugafuga.org")
-            .product("CMSIS-DAP")
-            .serial_number("serialnumber")
+            .strings(&[usb_strings])
+            .unwrap()
             .device_class(USB_CLASS_MISCELLANEOUS)
             .device_class(USB_SUBCLASS_COMMON)
             .device_protocol(USB_PROTOCOL_IAD)
             .composite_with_iads()
             .max_packet_size_0(64)
+            .unwrap()
             .build();
         assert!(dap.process().is_ok());
     }

--- a/rust-dap/src/interface.rs
+++ b/rust-dap/src/interface.rs
@@ -250,7 +250,7 @@ impl<B: UsbBus> UsbClass<B> for CmsisDapInterface<'_, B> {
         Ok(())
     }
 
-    fn get_string(&self, index: StringIndex, lang_id: u16) -> Option<&str> {
+    fn get_string(&self, index: StringIndex, lang_id: LangID) -> Option<&str> {
         let _ = lang_id;
         if index == self.serial_string {
             Some("CMSIS-DAP interface")


### PR DESCRIPTION
一つ目の commit で rp-pico=0.8 , rp2040-hal=0.9 , に更新し、
二つ目の commit で rp-pico=0.9 , rp2040-hal=0.10 および xiao_m0=0.13 , adsamd-hal=0.17 に更新します。

合わせて embedded-hal=1 、 usb-device=0.3 、usbd-serial=0.2 に更新します。

各所から feature unproven が消えました。

embedded-hal から IoPin がなくなったので代りに bitbang の下に入れてあります。

それぞれの package の version を更新しています。

rp2040-hal 0.10.2 の制約から MSRV は 1.75 となります。